### PR TITLE
Minor refactor

### DIFF
--- a/libslide/src/grammar.rs
+++ b/libslide/src/grammar.rs
@@ -7,6 +7,18 @@ pub enum Stmt {
     Assignment(Assignment),
 }
 
+impl From<Expr> for Stmt {
+    fn from(expr: Expr) -> Self {
+        Stmt::Expr(expr)
+    }
+}
+
+impl From<Assignment> for Stmt {
+    fn from(asgn: Assignment) -> Self {
+        Stmt::Assignment(asgn)
+    }
+}
+
 impl fmt::Display for Stmt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Stmt::*;
@@ -38,6 +50,36 @@ pub enum Expr {
     Var(Var),
     BinaryExpr(BinaryExpr),
     UnaryExpr(UnaryExpr),
+}
+
+impl From<f64> for Expr {
+    fn from(f: f64) -> Self {
+        Self::Float(f)
+    }
+}
+
+impl From<i64> for Expr {
+    fn from(i: i64) -> Self {
+        Self::Int(i)
+    }
+}
+
+impl From<Var> for Expr {
+    fn from(var: Var) -> Self {
+        Self::Var(var)
+    }
+}
+
+impl From<BinaryExpr> for Expr {
+    fn from(binary_expr: BinaryExpr) -> Self {
+        Self::BinaryExpr(binary_expr)
+    }
+}
+
+impl From<UnaryExpr> for Expr {
+    fn from(unary_expr: UnaryExpr) -> Self {
+        Self::UnaryExpr(unary_expr)
+    }
 }
 
 impl fmt::Display for Expr {

--- a/libslide/src/lib.rs
+++ b/libslide/src/lib.rs
@@ -1,8 +1,16 @@
-pub mod scanner;
+mod scanner;
+pub use scanner::scan;
 
-pub mod parser;
+mod parser;
+pub use parser::parse;
 
-pub mod partial_evaluator;
-pub mod visitor;
+mod partial_evaluator;
+pub use partial_evaluator::evaluate;
 
-pub mod printer;
+mod printer;
+pub use printer::print;
+
+mod grammar;
+mod visitor;
+
+mod utils;

--- a/libslide/src/partial_evaluator.rs
+++ b/libslide/src/partial_evaluator.rs
@@ -1,4 +1,4 @@
-use crate::parser::types::{BinaryExpr, Expr, UnaryExpr, Var};
+use crate::grammar::*;
 use crate::visitor::Visitor;
 pub mod types;
 use types::PEResult;
@@ -22,7 +22,7 @@ impl Visitor for PartialEvaluator {
     }
 
     fn visit_var(&mut self, item: Var) -> Self::Result {
-        PEResult::Unevaluated(Box::new(Expr::Var(item)))
+        Expr::Var(item).into()
     }
 
     fn visit_binary_expr(&mut self, item: BinaryExpr) -> Self::Result {
@@ -46,7 +46,7 @@ mod tests {
             fn $name() {
                 use crate::scanner::scan;
                 use crate::parser::parse;
-                use crate::parser::types::Stmt;
+                use crate::grammar::Stmt;
                 use crate::partial_evaluator::{evaluate, PEResult::*};
 
                 let tokens = scan($program);

--- a/libslide/src/printer.rs
+++ b/libslide/src/printer.rs
@@ -1,4 +1,4 @@
-use crate::parser::types::{BinaryExpr, Expr, UnaryExpr, Var};
+use crate::grammar::{BinaryExpr, Expr, UnaryExpr, Var};
 use crate::visitor::Visitor;
 
 pub fn print(expr: Expr) -> String {
@@ -44,9 +44,9 @@ mod tests {
         $(
             #[test]
             fn $name() {
+                use crate::grammar::Stmt;
                 use crate::scanner::scan;
                 use crate::parser::parse;
-                use crate::parser::types::Stmt;
                 use crate::printer::print;
 
                 let tokens = scan($program);

--- a/libslide/src/scanner.rs
+++ b/libslide/src/scanner.rs
@@ -23,7 +23,7 @@ impl Scanner {
 
     // matches token with symbol and creates it: private helper function
     fn create_symbol_token(c: char) -> Token {
-        let t = match c {
+        let ty = match c {
             '+' => TokenType::Plus,
             '-' => TokenType::Minus,
             '*' => TokenType::Mult,
@@ -37,7 +37,7 @@ impl Scanner {
             ']' => TokenType::CloseBracket,
             _ => TokenType::Invalid(c.to_string()),
         };
-        return Token { ty: t };
+        Token { ty }
     }
 
     // iterates through any digits to create a token of that value
@@ -68,7 +68,7 @@ impl Scanner {
                 ty: TokenType::Int(int_str.parse::<i64>().unwrap()),
             }
         }
-        return (ret, i);
+        (ret, i)
     }
 
     fn iterate_var(&mut self, mut i: usize) -> (Token, usize) {
@@ -80,7 +80,7 @@ impl Scanner {
         let var = Token {
             ty: TokenType::Variable(var_str),
         };
-        return (var, i);
+        (var, i)
     }
 
     pub fn scan(&mut self) {

--- a/libslide/src/utils.rs
+++ b/libslide/src/utils.rs
@@ -1,0 +1,6 @@
+pub fn map_box<T, U, F>(boxed: Box<T>, f: F) -> Box<U>
+where
+    F: Fn(T) -> U,
+{
+    Box::new(f(*boxed))
+}

--- a/libslide/src/visitor.rs
+++ b/libslide/src/visitor.rs
@@ -1,4 +1,4 @@
-use crate::parser::types::*;
+use crate::grammar::*;
 
 /// An expression visitor.
 /// This visitor takes ownership of the expressions it visits.


### PR DESCRIPTION
Adds `From` traits and moves parser types to `libslide/src/grammar`,
since the grammar is used in visitors as well.