### PR TITLE
Support paranthesized and braced expressions

### DIFF
--- a/libslide/src/grammar.rs
+++ b/libslide/src/grammar.rs
@@ -50,6 +50,10 @@ pub enum Expr {
     Var(Var),
     BinaryExpr(BinaryExpr),
     UnaryExpr(UnaryExpr),
+    /// An expression wrapped in parentheses
+    Parend(Box<Expr>),
+    /// An expression wrapped in braces
+    Braced(Box<Expr>),
 }
 
 impl From<f64> for Expr {
@@ -94,6 +98,7 @@ impl fmt::Display for Expr {
                 Var(var) => var.to_string(),
                 BinaryExpr(binary_expr) => binary_expr.to_string(),
                 UnaryExpr(unary_expr) => unary_expr.to_string(),
+                Parend(expr) | Braced(expr) => expr.to_string(),
             }
         )
     }

--- a/libslide/src/parser.rs
+++ b/libslide/src/parser.rs
@@ -123,9 +123,13 @@ impl Parser {
             TokenType::Float(f) => Expr::Float(f).into(),
             TokenType::Int(i) => Expr::Int(i).into(),
             TokenType::Variable(ref name) => Expr::Var(Var { name: name.clone() }).into(),
-            TokenType::OpenParen | TokenType::OpenBracket => {
+            TokenType::OpenParen => {
                 self.advance(); // eat left
-                self.expr()
+                Expr::Parend(self.expr()).into()
+            }
+            TokenType::OpenBracket => {
+                self.advance(); // eat left
+                Expr::Braced(self.expr()).into()
             }
             _ => unreachable!(),
         };

--- a/libslide/src/printer.rs
+++ b/libslide/src/printer.rs
@@ -35,6 +35,14 @@ impl Visitor for Printer {
     fn visit_unary_expr(&mut self, item: UnaryExpr) -> Self::Result {
         format!("{}{}", item.op.to_string(), self.visit_expr(*item.rhs))
     }
+
+    fn visit_parend(&mut self, item: Expr) -> Self::Result {
+        format!("({})", self.visit_expr(item))
+    }
+
+    fn visit_braced(&mut self, item: Expr) -> Self::Result {
+        format!("[{}]", self.visit_expr(item))
+    }
 }
 
 #[cfg(test)]
@@ -73,6 +81,8 @@ mod tests {
         exponent:        "1 ^ 2"
         sign_positive:   "+1"
         sign_negative:   "-1"
+        parenthesized:   "(1 + 2)"
+        braced:          "[1 + 2]"
 
         nested_binary:   "1 + 2 * 3 + 4"
     }

--- a/libslide/src/visitor.rs
+++ b/libslide/src/visitor.rs
@@ -12,6 +12,8 @@ pub trait Visitor {
             Expr::Var(v) => self.visit_var(v),
             Expr::BinaryExpr(binary_expr) => self.visit_binary_expr(binary_expr),
             Expr::UnaryExpr(unary_expr) => self.visit_unary_expr(unary_expr),
+            Expr::Parend(expr) => self.visit_parend(*expr),
+            Expr::Braced(expr) => self.visit_braced(*expr),
         }
     }
 
@@ -20,4 +22,14 @@ pub trait Visitor {
     fn visit_var(&mut self, item: Var) -> Self::Result;
     fn visit_binary_expr(&mut self, item: BinaryExpr) -> Self::Result;
     fn visit_unary_expr(&mut self, item: UnaryExpr) -> Self::Result;
+
+    /// Default visitor for parenthesized expressions: just visit the expression.
+    fn visit_parend(&mut self, item: Expr) -> Self::Result {
+        self.visit_expr(item)
+    }
+
+    /// Default visitor for braced expressions: just visit the expression.
+    fn visit_braced(&mut self, item: Expr) -> Self::Result {
+        self.visit_expr(item)
+    }
 }


### PR DESCRIPTION
The printer needs to know about paranthesized and braced expressions to
print parsed expressions correctly.

Closes #21.