### PR TITLE
Remove printer in favor of grammars' display trait

### DIFF
--- a/libslide/src/grammar.rs
+++ b/libslide/src/grammar.rs
@@ -1,4 +1,3 @@
-use crate::printer::Print;
 use crate::scanner::types::{Token, TokenType};
 use crate::visitor::Visitor;
 use core::convert::TryFrom;
@@ -42,7 +41,7 @@ pub struct Assignment {
 
 impl fmt::Display for Assignment {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(= {} {})", self.var, self.rhs)
+        write!(f, "{} = {}", self.var, self.rhs)
     }
 }
 
@@ -56,13 +55,6 @@ pub enum Expr {
     Parend(Box<Expr>),
     /// An expression wrapped in braces
     Braced(Box<Expr>),
-}
-
-impl Print for Expr {
-    fn print(self) -> String {
-        let mut printer = ExprPrinter;
-        printer.visit_expr(self)
-    }
 }
 
 struct ExprPrinter;
@@ -146,7 +138,8 @@ impl fmt::Display for Expr {
                 Var(var) => var.to_string(),
                 BinaryExpr(binary_expr) => binary_expr.to_string(),
                 UnaryExpr(unary_expr) => unary_expr.to_string(),
-                Parend(expr) | Braced(expr) => expr.to_string(),
+                Parend(expr) => format!("({})", expr.to_string()),
+                Braced(expr) => format!("[{}]", expr.to_string()),
             }
         )
     }
@@ -216,9 +209,9 @@ impl fmt::Display for BinaryExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "({} {} {})",
-            self.op.to_string(),
+            "{} {} {}",
             self.lhs.to_string(),
+            self.op.to_string(),
             self.rhs.to_string(),
         )
     }
@@ -263,49 +256,6 @@ pub struct UnaryExpr {
 
 impl fmt::Display for UnaryExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "({} {})", self.op.to_string(), self.rhs.to_string(),)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    macro_rules! printer_tests {
-        ($($name:ident: $program:expr)*) => {
-        $(
-            #[test]
-            fn $name() {
-                use crate::grammar::Stmt;
-                use crate::scanner::scan;
-                use crate::parser::parse;
-                use crate::printer::Print;
-
-                let tokens = scan($program);
-                let parsed = match parse(tokens) {
-                    Stmt::Expr(expr) => expr,
-                    Stmt::Assignment(_) => unimplemented!(),
-                };
-
-                assert_eq!(parsed.print(), $program.to_string())
-            }
-        )*
-        }
-    }
-
-    printer_tests! {
-        int:             "1"
-        float:           "1.1"
-        var:             "a"
-        addition:        "1 + 2"
-        subtraction:     "1 - 2"
-        multiplication:  "1 * 2"
-        division:        "1 / 2"
-        modulo:          "1 % 2"
-        exponent:        "1 ^ 2"
-        sign_positive:   "+1"
-        sign_negative:   "-1"
-        parenthesized:   "(1 + 2)"
-        braced:          "[1 + 2]"
-
-        nested_binary:   "1 + 2 * 3 + 4"
+        write!(f, "{}{}", self.op.to_string(), self.rhs.to_string(),)
     }
 }

--- a/libslide/src/lib.rs
+++ b/libslide/src/lib.rs
@@ -7,8 +7,5 @@ pub use parser::parse;
 mod partial_evaluator;
 pub use partial_evaluator::evaluate;
 
-mod printer;
-pub use printer::print;
-
 mod grammar;
 mod visitor;

--- a/libslide/src/parser.rs
+++ b/libslide/src/parser.rs
@@ -138,7 +138,7 @@ mod tests {
     // See [Expr]'s impl of Display for more details.
     // [Expr]: crate::parser::Expr
     macro_rules! parser_tests {
-        ($($name:ident: $program:expr, $format_str:expr)*) => {
+        ($($name:ident: $program:expr)*) => {
         $(
             #[test]
             fn $name() {
@@ -147,7 +147,7 @@ mod tests {
 
                 let tokens = scan($program);
                 let parsed = parse(tokens);
-                assert_eq!(parsed.to_string(), $format_str);
+                assert_eq!(parsed.to_string(), $program);
             }
         )*
         }
@@ -155,56 +155,56 @@ mod tests {
 
     mod parse {
         parser_tests! {
-            addition:                "2 + 2",               "(+ 2 2)"
-            addition_nested:         "1 + 2 + 3",           "(+ (+ 1 2) 3)"
-            subtraction:             "2 - 2",               "(- 2 2)"
-            subtraction_nested:      "1 - 2 - 3",           "(- (- 1 2) 3)"
-            multiplication:          "2 * 2",               "(* 2 2)"
-            multiplication_nested:   "1 * 2 * 3",           "(* (* 1 2) 3)"
-            division:                "2 / 2",               "(/ 2 2)"
-            division_nested:         "1 / 2 / 3",           "(/ (/ 1 2) 3)"
-            modulo:                  "2 % 5",               "(% 2 5)"
-            modulo_nested:           "1 % 2 % 3",           "(% (% 1 2) 3)"
-            exponent:                "2 ^ 3",               "(^ 2 3)"
-            exponent_nested:         "1 ^ 2 ^ 3",           "(^ 1 (^ 2 3))"
-            precedence_plus_times:   "1 + 2 * 3",           "(+ 1 (* 2 3))"
-            precedence_times_plus:   "1 * 2 + 3",           "(+ (* 1 2) 3)"
-            precedence_plus_div:     "1 + 2 / 3",           "(+ 1 (/ 2 3))"
-            precedence_div_plus:     "1 / 2 + 3",           "(+ (/ 1 2) 3)"
-            precedence_plus_mod:     "1 + 2 % 3",           "(+ 1 (% 2 3))"
-            precedence_mod_plus:     "1 % 2 + 3",           "(+ (% 1 2) 3)"
-            precedence_minus_times:  "1 - 2 * 3",           "(- 1 (* 2 3))"
-            precedence_times_minus:  "1 * 2 - 3",           "(- (* 1 2) 3)"
-            precedence_minus_div:    "1 - 2 / 3",           "(- 1 (/ 2 3))"
-            precedence_div_minus:    "1 / 2 - 3",           "(- (/ 1 2) 3)"
-            precedence_minus_mod:    "1 - 2 % 3",           "(- 1 (% 2 3))"
-            precedence_mod_minus:    "1 % 2 - 3",           "(- (% 1 2) 3)"
-            precedence_expo_plus:    "1 + 2 ^ 3",           "(+ 1 (^ 2 3))"
-            precedence_plus_exp:     "1 ^ 2 + 3",           "(+ (^ 1 2) 3)"
-            precedence_expo_times:   "1 * 2 ^ 3",           "(* 1 (^ 2 3))"
-            precedence_time_expo:    "1 ^ 2 * 3",           "(* (^ 1 2) 3)"
-            parentheses_plus_times:  "(1 + 2) * 3",         "(* (+ 1 2) 3)"
-            parentheses_time_plus:   "3 * (1 + 2)",         "(* 3 (+ 1 2))"
-            parentheses_time_mod:    "3 * (2 % 2)",         "(* 3 (% 2 2))"
-            parentheses_mod_time:    "(2 % 2) * 3",         "(* (% 2 2) 3)"
-            parentheses_exp_time:    "2 ^ (3 ^ 4 * 5)",     "(^ 2 (* (^ 3 4) 5))"
-            parentheses_unary:       "-(2 + +-5)",          "(- (+ 2 (+ (- 5))))"
-            nested_parentheses:      "((1 * (2 + 3)) ^ 4)", "(^ (* 1 (+ 2 3)) 4)"
-            brackets_plus_times:     "[1 + 2] * 3",         "(* (+ 1 2) 3)"
-            brackets_time_plus:      "3 * [1 + 2]",         "(* 3 (+ 1 2))"
-            brackets_time_mod:       "3 * [2 % 2]",         "(* 3 (% 2 2))"
-            brackets_mod_time:       "[2 % 2] * 3",         "(* (% 2 2) 3)"
-            brackets_exp_time:       "2 ^ [3 ^ 4 * 5]",     "(^ 2 (* (^ 3 4) 5))"
-            brackets_unary:          "-[2 + +-5]",          "(- (+ 2 (+ (- 5))))"
-            nested_brackets:         "[[1 * [2 + 3]] ^ 4]", "(^ (* 1 (+ 2 3)) 4)"
-            unary_minus:             "-2",                  "(- 2)"
-            unary_expo:              "-2 ^ 3",              "(- (^ 2 3))"
-            unary_quad:              "+-+-2",               "(+ (- (+ (- 2))))"
-            variable:                "a",                   "a"
-            variable_in_op_left:     "a + 1",               "(+ a 1)"
-            variable_in_op_right:    "1 + a",               "(+ 1 a)"
-            assignment_op:           "a = 5",               "(= a 5)"
-            assignment_op_expr:      "a = 5 + 2 ^ 3",       "(= a (+ 5 (^ 2 3)))"
+            addition:                "2 + 2"
+            addition_nested:         "1 + 2 + 3"
+            subtraction:             "2 - 2"
+            subtraction_nested:      "1 - 2 - 3"
+            multiplication:          "2 * 2"
+            multiplication_nested:   "1 * 2 * 3"
+            division:                "2 / 2"
+            division_nested:         "1 / 2 / 3"
+            modulo:                  "2 % 5"
+            modulo_nested:           "1 % 2 % 3"
+            exponent:                "2 ^ 3"
+            exponent_nested:         "1 ^ 2 ^ 3"
+            precedence_plus_times:   "1 + 2 * 3"
+            precedence_times_plus:   "1 * 2 + 3"
+            precedence_plus_div:     "1 + 2 / 3"
+            precedence_div_plus:     "1 / 2 + 3"
+            precedence_plus_mod:     "1 + 2 % 3"
+            precedence_mod_plus:     "1 % 2 + 3"
+            precedence_minus_times:  "1 - 2 * 3"
+            precedence_times_minus:  "1 * 2 - 3"
+            precedence_minus_div:    "1 - 2 / 3"
+            precedence_div_minus:    "1 / 2 - 3"
+            precedence_minus_mod:    "1 - 2 % 3"
+            precedence_mod_minus:    "1 % 2 - 3"
+            precedence_expo_plus:    "1 + 2 ^ 3"
+            precedence_plus_exp:     "1 ^ 2 + 3"
+            precedence_expo_times:   "1 * 2 ^ 3"
+            precedence_time_expo:    "1 ^ 2 * 3"
+            parentheses_plus_times:  "(1 + 2) * 3"
+            parentheses_time_plus:   "3 * (1 + 2)"
+            parentheses_time_mod:    "3 * (2 % 2)"
+            parentheses_mod_time:    "(2 % 2) * 3"
+            parentheses_exp_time:    "2 ^ (3 ^ 4 * 5)"
+            parentheses_unary:       "-(2 + +-5)"
+            nested_parentheses:      "((1 * (2 + 3)) ^ 4)"
+            brackets_plus_times:     "[1 + 2] * 3"
+            brackets_time_plus:      "3 * [1 + 2]"
+            brackets_time_mod:       "3 * [2 % 2]"
+            brackets_mod_time:       "[2 % 2] * 3"
+            brackets_exp_time:       "2 ^ [3 ^ 4 * 5]"
+            brackets_unary:          "-[2 + +-5]"
+            nested_brackets:         "[[1 * [2 + 3]] ^ 4]"
+            unary_minus:             "-2"
+            unary_expo:              "-2 ^ 3"
+            unary_quad:              "+-+-2"
+            variable:                "a"
+            variable_in_op_left:     "a + 1"
+            variable_in_op_right:    "1 + a"
+            assignment_op:           "a = 5"
+            assignment_op_expr:      "a = 5 + 2 ^ 3"
         }
     }
 }

--- a/libslide/src/partial_evaluator.rs
+++ b/libslide/src/partial_evaluator.rs
@@ -89,16 +89,16 @@ mod tests {
     mod unevaluated {
         partial_evaluator_tests! {
             var:                     "a",                   "a"
-            sign_positive_var:       "+a",                  "(+ a)"
-            sign_negative_var:       "-a",                  "(- a)"
-            addition_var:            "a + b",               "(+ a b)"
-            substraction_var:        "a - b",               "(- a b)"
-            mult_var:                "a * b",               "(* a b)"
-            div_var:                 "a / b",               "(/ a b)"
-            mod_var:                 "a % b",               "(% a b)"
-            exp_var:                 "a ^ b",               "(^ a b)"
-            pe_left:                 "1 + 2 + a",           "(+ 3 a)"
-            pe_right:                "a + 1 + 2",           "(+ (+ a 1) 2)"
+            sign_positive_var:       "+a",                  "+a"
+            sign_negative_var:       "-a",                  "-a"
+            addition_var:            "a + b",               "a + b"
+            substraction_var:        "a - b",               "a - b"
+            mult_var:                "a * b",               "a * b"
+            div_var:                 "a / b",               "a / b"
+            mod_var:                 "a % b",               "a % b"
+            exp_var:                 "a ^ b",               "a ^ b"
+            pe_left:                 "1 + 2 + a",           "3 + a"
+            pe_right:                "a + 1 + 2",           "a + 1 + 2"
         }
     }
 }

--- a/libslide/src/partial_evaluator/types.rs
+++ b/libslide/src/partial_evaluator/types.rs
@@ -1,19 +1,9 @@
 use crate::grammar::*;
-use crate::printer::Print;
 use core::fmt;
 
 pub enum PEResult {
     Evaluated(f64),
     Unevaluated(Box<Expr>),
-}
-
-impl Print for PEResult {
-    fn print(self) -> String {
-        match self {
-            Self::Evaluated(x) => x.to_string(),
-            Self::Unevaluated(expr) => expr.print(),
-        }
-    }
 }
 
 impl From<Expr> for PEResult {

--- a/libslide/src/printer.rs
+++ b/libslide/src/printer.rs
@@ -1,7 +1,0 @@
-pub fn print<T: Print>(obj: T) -> String {
-    obj.print()
-}
-
-pub trait Print {
-    fn print(self) -> String;
-}

--- a/slide/src/main.rs
+++ b/slide/src/main.rs
@@ -1,4 +1,4 @@
-use libslide::{evaluate, parse, print, scan};
+use libslide::{evaluate, parse, scan};
 
 use std::env;
 
@@ -13,7 +13,7 @@ fn main() -> Result<(), &'static str> {
     let parse_tree = parse(scan(program));
     let simplified = evaluate(parse_tree);
 
-    println!("{}", print(simplified));
+    println!("{}", simplified.to_string());
 
     Ok(())
 }


### PR DESCRIPTION
It's probably better to reconcile two ways of displaying the grammar to
one cononical way, that can also be used to output the grammar in an
expected-output form.