### PR TITLE
Common subexpression elimination

### DIFF
--- a/libslide/src/evaluator_rules/registry/fn_rules.rs
+++ b/libslide/src/evaluator_rules/registry/fn_rules.rs
@@ -3,10 +3,12 @@ use crate::grammar::*;
 macro_rules! get_binary_args {
     ($expr:expr, $op:pat) => {
         match $expr {
-            Expr::BinaryExpr(BinaryExpr { op: $op, lhs, rhs }) => match (*lhs, *rhs) {
-                (Expr::Const(l), Expr::Const(r)) => Some((l, r)),
-                _ => None,
-            },
+            Expr::BinaryExpr(BinaryExpr { op: $op, lhs, rhs }) => {
+                match (lhs.as_ref(), rhs.as_ref()) {
+                    (Expr::Const(l), Expr::Const(r)) => Some((l, r)),
+                    _ => None,
+                }
+            }
             _ => None,
         }
     };
@@ -15,48 +17,48 @@ macro_rules! get_binary_args {
 macro_rules! get_unary_arg {
     ($expr:expr, $op:pat) => {
         match $expr {
-            Expr::UnaryExpr(UnaryExpr { op: $op, rhs }) => Some(*rhs),
+            Expr::UnaryExpr(UnaryExpr { op: $op, rhs }) => Some(rhs),
             _ => None,
         }
     };
 }
 
-pub(super) fn add(expr: Expr) -> Option<Expr> {
+pub(super) fn add(expr: &Expr) -> Option<Expr> {
     let (l, r) = get_binary_args!(expr, BinaryOperator::Plus)?;
     Some(Expr::Const(l + r))
 }
 
-pub(super) fn subtract(expr: Expr) -> Option<Expr> {
+pub(super) fn subtract(expr: &Expr) -> Option<Expr> {
     let (l, r) = get_binary_args!(expr, BinaryOperator::Minus)?;
     Some(Expr::Const(l - r))
 }
 
-pub(super) fn multiply(expr: Expr) -> Option<Expr> {
+pub(super) fn multiply(expr: &Expr) -> Option<Expr> {
     let (l, r) = get_binary_args!(expr, BinaryOperator::Mult)?;
     Some(Expr::Const(l * r))
 }
 
-pub(super) fn divide(expr: Expr) -> Option<Expr> {
+pub(super) fn divide(expr: &Expr) -> Option<Expr> {
     let (l, r) = get_binary_args!(expr, BinaryOperator::Div)?;
     Some(Expr::Const(l / r))
 }
 
-pub(super) fn modulo(expr: Expr) -> Option<Expr> {
+pub(super) fn modulo(expr: &Expr) -> Option<Expr> {
     let (l, r) = get_binary_args!(expr, BinaryOperator::Mod)?;
     Some(Expr::Const(l % r))
 }
 
-pub(super) fn exponentiate(expr: Expr) -> Option<Expr> {
+pub(super) fn exponentiate(expr: &Expr) -> Option<Expr> {
     let (l, r) = get_binary_args!(expr, BinaryOperator::Exp)?;
-    Some(Expr::Const(l.powf(r)))
+    Some(Expr::Const(l.powf(*r)))
 }
 
-pub(super) fn posate(expr: Expr) -> Option<Expr> {
-    get_unary_arg!(expr, UnaryOperator::SignPositive)
+pub(super) fn posate(expr: &Expr) -> Option<Expr> {
+    get_unary_arg!(expr, UnaryOperator::SignPositive).map(|e| e.as_ref().clone())
 }
 
-pub(super) fn negate(expr: Expr) -> Option<Expr> {
-    match get_unary_arg!(expr, UnaryOperator::SignNegative)? {
+pub(super) fn negate(expr: &Expr) -> Option<Expr> {
+    match get_unary_arg!(expr, UnaryOperator::SignNegative)?.as_ref() {
         Expr::Const(n) => Some(Expr::Const(-n)),
         _ => None,
     }

--- a/libslide/src/evaluator_rules/unbuilt_rule.rs
+++ b/libslide/src/evaluator_rules/unbuilt_rule.rs
@@ -41,5 +41,5 @@ pub enum UnbuiltRule {
     M(&'static [&'static str]),
 
     /// A function rule.
-    F(fn(Expr) -> Option<Expr>),
+    F(fn(&Expr) -> Option<Expr>),
 }

--- a/libslide/src/parser/expression_parser.rs
+++ b/libslide/src/parser/expression_parser.rs
@@ -1,27 +1,33 @@
 use super::Parser;
-
 use crate::grammar::*;
 use crate::scanner::types::{Token, TokenType};
-use crate::utils::{PeekIter, StringUtils};
+use crate::utils::{hash, PeekIter, StringUtils};
+
+use std::collections::HashMap;
+use std::rc::Rc;
 
 pub fn parse(input: Vec<Token>) -> (Stmt, Vec<String>) {
     let mut parser = ExpressionParser::new(input);
     let parsed = parser.parse();
     let errors = parser.errors().iter().map(|e| e.to_string()).collect();
-    (*parsed, errors)
+    (parsed, errors)
 }
 
 pub struct ExpressionParser {
     _input: PeekIter<Token>,
     _errors: Vec<String>,
+    // We use an untyped hash here because we don't want to clone an Expr into the map in case it's
+    // already there when using an entry API.
+    // TODO: replace with Expr when raw_entry API is stabilized (see rust#56167)
+    seen: HashMap<u64, Rc<Expr>>,
 }
 
 impl ExpressionParser {
-    fn assignment(&mut self, var: String) -> Box<Stmt> {
-        Box::new(Stmt::Assignment(Assignment {
+    fn assignment(&mut self, var: String) -> Stmt {
+        Stmt::Assignment(Assignment {
             var,
             rhs: self.expr(),
-        }))
+        })
     }
 }
 
@@ -47,21 +53,8 @@ impl Parser<Stmt> for ExpressionParser {
         Self {
             _input: PeekIter::new(input.into_iter()),
             _errors: vec![],
+            seen: HashMap::new(),
         }
-    }
-
-    fn parse(&mut self) -> Box<Stmt> {
-        let mut next_2 = self.input().peek_map_n(2, |tok| tok.ty.clone());
-        let parsed = match (next_2.pop_front(), next_2.pop_front()) {
-            (Some(TokenType::Variable(name)), Some(TokenType::Equal)) => {
-                self.input().next();
-                self.input().next();
-                self.assignment(name)
-            }
-            _ => Box::new(Stmt::Expr(*self.expr())),
-        };
-        assert!(self.done());
-        parsed
     }
 
     fn errors(&self) -> &Vec<Self::Error> {
@@ -70,6 +63,20 @@ impl Parser<Stmt> for ExpressionParser {
 
     fn input(&mut self) -> &mut PeekIter<Token> {
         &mut self._input
+    }
+
+    fn parse(&mut self) -> Stmt {
+        let mut next_2 = self.input().peek_map_n(2, |tok| tok.ty.clone());
+        let parsed = match (next_2.pop_front(), next_2.pop_front()) {
+            (Some(TokenType::Variable(name)), Some(TokenType::Equal)) => {
+                self.input().next();
+                self.input().next();
+                self.assignment(name)
+            }
+            _ => Stmt::Expr((*self.expr()).clone()),
+        };
+        assert!(self.done());
+        parsed
     }
 
     fn parse_float(&mut self, f: f64) -> Self::Expr {
@@ -101,10 +108,21 @@ impl Parser<Stmt> for ExpressionParser {
         self.input().next(); // eat open paren
         Self::Expr::Braced(self.expr())
     }
+
+    fn finish_expr(&mut self, expr: Self::Expr) -> Rc<Self::Expr> {
+        let p = self
+            .seen
+            .entry(hash(&expr))
+            .or_insert_with(|| Rc::new(expr));
+        Rc::clone(p)
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::scan;
+
     parser_tests! {
         parse_expression
 
@@ -130,5 +148,31 @@ mod tests {
                                                       "\n",
                                                       r##"The pattern "$a" cannot be used in an expression. "##,
                                                       r#"Consider using "a" as a variable instead."#)
+    }
+
+    #[test]
+    fn common_subexpression_elimination() {
+        let program = "1 * 2 + 1 * 2";
+        let tokens = scan(program);
+        let (parsed, _) = parse(tokens);
+        let (l, r) = match parsed {
+            Stmt::Expr(Expr::BinaryExpr(BinaryExpr { lhs, rhs, .. })) => (lhs, rhs),
+            _ => unreachable!(),
+        };
+        assert!(std::ptr::eq(l.as_ref(), r.as_ref())); // 1 * 2
+
+        let (ll, lr, rl, rr) = match (l.as_ref(), r.as_ref()) {
+            (
+                Expr::BinaryExpr(BinaryExpr {
+                    lhs: ll, rhs: lr, ..
+                }),
+                Expr::BinaryExpr(BinaryExpr {
+                    lhs: rl, rhs: rr, ..
+                }),
+            ) => (ll, lr, rl, rr),
+            _ => unreachable!(),
+        };
+        assert!(std::ptr::eq(ll.as_ref(), rl.as_ref())); // 1
+        assert!(std::ptr::eq(lr.as_ref(), rr.as_ref())); // 2
     }
 }

--- a/libslide/src/parser/expression_pattern_parser.rs
+++ b/libslide/src/parser/expression_pattern_parser.rs
@@ -1,19 +1,25 @@
 use super::Parser;
-
 use crate::grammar::*;
 use crate::scanner::types::Token;
-use crate::utils::PeekIter;
+use crate::utils::{hash, PeekIter};
+
+use std::collections::HashMap;
+use std::rc::Rc;
 
 pub fn parse(input: Vec<Token>) -> (ExprPat, Vec<String>) {
     let mut parser = ExpressionPatternParser::new(input);
     let parsed = parser.parse();
     let errors = parser.errors().iter().map(|e| e.to_string()).collect();
-    (*parsed, errors)
+    (parsed, errors)
 }
 
 pub struct ExpressionPatternParser {
     _input: PeekIter<Token>,
     _errors: Vec<String>,
+    // We use an untyped hash here because we don't want to clone an Expr into the map in case it's
+    // already there when using an entry API.
+    // TODO: replace with Expr when raw_entry API is stabilized (see rust#56167)
+    seen: HashMap<u64, Rc<ExprPat>>,
 }
 
 impl Parser<ExprPat> for ExpressionPatternParser {
@@ -24,13 +30,8 @@ impl Parser<ExprPat> for ExpressionPatternParser {
         Self {
             _input: PeekIter::new(input.into_iter()),
             _errors: vec![],
+            seen: HashMap::new(),
         }
-    }
-
-    fn parse(&mut self) -> Box<ExprPat> {
-        let parsed = Box::new(*self.expr());
-        assert!(self.done());
-        parsed
     }
 
     fn errors(&self) -> &Vec<Self::Error> {
@@ -39,6 +40,12 @@ impl Parser<ExprPat> for ExpressionPatternParser {
 
     fn input(&mut self) -> &mut PeekIter<Token> {
         &mut self._input
+    }
+
+    fn parse(&mut self) -> ExprPat {
+        let parsed = self.expr();
+        assert!(self.done());
+        (*parsed).clone()
     }
 
     fn parse_float(&mut self, f: f64) -> Self::Expr {
@@ -77,10 +84,21 @@ impl Parser<ExprPat> for ExpressionPatternParser {
         self.input().next(); // eat open paren
         Self::Expr::Braced(self.expr())
     }
+
+    fn finish_expr(&mut self, expr: Self::Expr) -> Rc<Self::Expr> {
+        let p = self
+            .seen
+            .entry(hash(&expr))
+            .or_insert_with(|| Rc::new(expr));
+        Rc::clone(p)
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::scan;
+
     parser_tests! {
         parse_expression_pattern
 
@@ -100,5 +118,31 @@ mod tests {
                                                     "\n",
                                                     r#"The variable "b" cannot be used in an expression pattern. "#,
                                                     r##"Consider using "$b", "#b", or "_b" as a variable instead."##)
+    }
+
+    #[test]
+    fn common_subexpression_elimination() {
+        let program = "$v * #c + $v * #c";
+        let tokens = scan(program);
+        let (parsed, _) = parse(tokens);
+        let (l, r) = match parsed {
+            ExprPat::BinaryExpr(BinaryExpr { lhs, rhs, .. }) => (lhs, rhs),
+            _ => unreachable!(),
+        };
+        assert!(std::ptr::eq(l.as_ref(), r.as_ref())); // $v * #c
+
+        let (ll, lr, rl, rr) = match (l.as_ref(), r.as_ref()) {
+            (
+                ExprPat::BinaryExpr(BinaryExpr {
+                    lhs: ll, rhs: lr, ..
+                }),
+                ExprPat::BinaryExpr(BinaryExpr {
+                    lhs: rl, rhs: rr, ..
+                }),
+            ) => (ll, lr, rl, rr),
+            _ => unreachable!(),
+        };
+        assert!(std::ptr::eq(ll.as_ref(), rl.as_ref())); // 1
+        assert!(std::ptr::eq(lr.as_ref(), rr.as_ref())); // 2
     }
 }

--- a/libslide/src/utils.rs
+++ b/libslide/src/utils.rs
@@ -1,3 +1,6 @@
+mod hash;
+pub use hash::*;
+
 mod iter;
 pub use iter::*;
 

--- a/libslide/src/utils/hash.rs
+++ b/libslide/src/utils/hash.rs
@@ -1,0 +1,9 @@
+use core::hash::{Hash, Hasher};
+use std::collections::hash_map::DefaultHasher;
+
+pub fn hash<T: Hash>(expr: &T) -> u64 {
+    // There is no way to reset a hasher's state, so we create a new one each time.
+    let mut hasher = DefaultHasher::new();
+    expr.hash(&mut hasher);
+    hasher.finish()
+}


### PR DESCRIPTION
We do this by passing reference-counted pointers around in place of
expression objects.

I'm actually not sure if this is worth the overhead compared to what we
already had. @luke-bhan could you give me a thorough review on this one?

Closes #46