### PR TITLE
Apply rules on associative nodes

### DIFF
--- a/libslide/src/evaluator_rules/rule.rs
+++ b/libslide/src/evaluator_rules/rule.rs
@@ -1,6 +1,6 @@
 use super::pattern_match::{MatchRule, PatternMatch};
 use crate::grammar::*;
-use crate::utils::hash;
+use crate::utils::{get_symmetric_expressions, hash};
 use crate::{parse_expression_pattern, scan};
 
 use core::fmt;
@@ -103,44 +103,51 @@ impl Transformer<Rc<Expr>, Rc<Expr>> for Rule {
                 return Rc::clone(result);
             }
 
-            // First, apply the rule recursively on the target's subexpressions.
-            let partially_transformed = match target.as_ref() {
-                Expr::Const(_) => Rc::clone(&target),
-                Expr::Var(_) => Rc::clone(&target),
-                Expr::BinaryExpr(binary_expr) => Expr::BinaryExpr(BinaryExpr {
-                    op: binary_expr.op,
-                    lhs: transform(rule, Rc::clone(&binary_expr.lhs), cache),
-                    rhs: transform(rule, Rc::clone(&binary_expr.rhs), cache),
-                })
-                .into(),
-                Expr::UnaryExpr(unary_expr) => Expr::UnaryExpr(UnaryExpr {
-                    op: unary_expr.op,
-                    rhs: transform(rule, Rc::clone(&unary_expr.rhs), cache),
-                })
-                .into(),
-                Expr::Parend(expr) => {
-                    let inner = transform(rule, Rc::clone(expr), cache);
-                    Expr::Parend(inner).into()
+            let mut result = Rc::clone(&target);
+            for target in get_symmetric_expressions(Rc::clone(&target)) {
+                // First, apply the rule recursively on the target's subexpressions.
+                let partially_transformed = match target.as_ref() {
+                    Expr::Const(_) => Rc::clone(&target),
+                    Expr::Var(_) => Rc::clone(&target),
+                    Expr::BinaryExpr(binary_expr) => Expr::BinaryExpr(BinaryExpr {
+                        op: binary_expr.op,
+                        lhs: transform(rule, Rc::clone(&binary_expr.lhs), cache),
+                        rhs: transform(rule, Rc::clone(&binary_expr.rhs), cache),
+                    })
+                    .into(),
+                    Expr::UnaryExpr(unary_expr) => Expr::UnaryExpr(UnaryExpr {
+                        op: unary_expr.op,
+                        rhs: transform(rule, Rc::clone(&unary_expr.rhs), cache),
+                    })
+                    .into(),
+                    Expr::Parend(expr) => {
+                        let inner = transform(rule, Rc::clone(expr), cache);
+                        Expr::Parend(inner).into()
+                    }
+                    Expr::Braced(expr) => {
+                        let inner = transform(rule, Rc::clone(expr), cache);
+                        Expr::Braced(inner).into()
+                    }
+                };
+                if partially_transformed.complexity() < result.complexity() {
+                    result = Rc::clone(&partially_transformed);
                 }
-                Expr::Braced(expr) => {
-                    let inner = transform(rule, Rc::clone(expr), cache);
-                    Expr::Braced(inner).into()
-                }
-            };
 
-            let transformed = match rule {
-                Rule::PatternMap(PatternMap { from, to }) => {
-                    PatternMatch::match_rule(Rc::clone(from), Rc::clone(&partially_transformed))
-                        // If the rule was matched on the expression, we have replacements for rule
-                        // patterns -> target subexpressions. Apply the rule by transforming the
-                        // rule's RHS with the replacements.
-                        .map(|repls| repls.transform(Rc::clone(to)))
+                if let Some(transformed) = match rule {
+                    Rule::PatternMap(PatternMap { from, to }) => {
+                        PatternMatch::match_rule(Rc::clone(from), Rc::clone(&partially_transformed))
+                            // If the rule was matched on the expression, we have replacements for rule
+                            // patterns -> target subexpressions. Apply the rule by transforming the
+                            // rule's RHS with the replacements.
+                            .map(|repls| repls.transform(Rc::clone(to)))
+                    }
+                    Rule::Evaluate(f) => f(partially_transformed.as_ref()).map(Rc::new),
+                } {
+                    return transformed;
                 }
-                Rule::Evaluate(f) => f(partially_transformed.as_ref()).map(Rc::new),
             }
-            .unwrap_or(partially_transformed);
 
-            fill(cache, target, transformed)
+            fill(cache, target, result)
         }
 
         let mut cache: HashMap<u64, Rc<Expr>> = HashMap::new();

--- a/libslide/src/grammar.rs
+++ b/libslide/src/grammar.rs
@@ -76,6 +76,18 @@ pub enum Expr {
     Braced(Rc<Self>),
 }
 
+impl Expr {
+    pub fn complexity(&self) -> u8 {
+        1 + match self {
+            Self::Const(_) => 0,
+            Self::Var(_) => 0,
+            Self::BinaryExpr(BinaryExpr { lhs, rhs, .. }) => lhs.complexity() + rhs.complexity(),
+            Self::UnaryExpr(UnaryExpr { rhs, .. }) => rhs.complexity(),
+            Self::Parend(expr) | Self::Braced(expr) => expr.complexity(),
+        }
+    }
+}
+
 impl Eq for Expr {}
 
 // TODO: We can do better than hashing to a string as well, but we'll save that til we have an

--- a/libslide/src/partial_evaluator.rs
+++ b/libslide/src/partial_evaluator.rs
@@ -56,13 +56,9 @@ mod tests {
             #[test]
             fn $name() {
                 let parsed = parse($program);
+                let evaluated = evaluate(parsed.clone(), EvaluatorContext::default());
 
-                // The order of rules applied in partial evaluation is non-determinstic (nor should
-                // it be), so run the evaluation a number of times for sanity.
-                for _ in 0..100 {
-                    let evaluated = evaluate(parsed.clone(), EvaluatorContext::default());
-                    assert_eq!(evaluated.to_string(), $result.to_string());
-                }
+                assert_eq!(evaluated.to_string(), $result.to_string());
             }
         )*
         }
@@ -71,10 +67,8 @@ mod tests {
     partial_evaluator_tests! {
         add:                            "1 + 2"     => "3"
         add_nested_left:                "1 + 2 + a" => "a + 3"
-        // TODO: This doesn't work yet... we need to be smarter, maybe by rewritting associativity
-        // or flipping constants between passes.
-        // add_nested_right:               "a + 1 + 2" => "a + 3"
-        // add_nested_with_reorder:        "1 + a + 2" => "a + 3"
+        add_nested_right:               "a + 1 + 2" => "a + 3"
+        add_nested_with_reorder:        "1 + a + 2" => "a + 3"
 
         sub:                            "1 - 2"     => "-1"
         sub_nested_left:                "1 - 2 - a" => "-1 - a"
@@ -109,8 +103,8 @@ mod tests {
         additive_identity_with_reorder: "0 + a + 0"   => "a"
 
         reorder_constants:              "1 + a"     => "a + 1"
-        reorder_constants_nested:       "1 + a + 2" => "a + 1 + 2"
-        reorder_constants_nested_left:  "a + 1 + 2" => "a + 1 + 2"
+        reorder_constants_nested:       "1 + a + 2" => "a + 3"
+        reorder_constants_nested_left:  "a + 1 + 2" => "a + 3"
         reorder_constants_nested_right: "1 + 2 + a" => "a + 3"
 
         distribute_negation:            "-(a - b)"     => "b - a"

--- a/libslide/src/utils.rs
+++ b/libslide/src/utils.rs
@@ -1,3 +1,6 @@
+mod grammar;
+pub use grammar::*;
+
 mod hash;
 pub use hash::*;
 

--- a/libslide/src/utils/grammar.rs
+++ b/libslide/src/utils/grammar.rs
@@ -1,0 +1,242 @@
+use crate::grammar::*;
+
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+pub fn get_symmetric_expressions(expr: Rc<Expr>) -> Vec<Rc<Expr>> {
+    match expr.as_ref() {
+        Expr::BinaryExpr(BinaryExpr { op, .. }) => match op {
+            BinaryOperator::Plus | BinaryOperator::Mult => {
+                let args = get_flattened_binary_args(Rc::clone(&expr), *op);
+                let mut sym_args = Vec::with_capacity(args.len());
+                let mut result = Vec::with_capacity((args.len() - 1) * 2);
+                for i in 0..args.len() {
+                    sym_args.push(Rc::clone(&args[i]));
+                    for arg in args.iter().take(i) {
+                        sym_args.push(Rc::clone(arg));
+                    }
+                    for arg in args.iter().skip(i + 1) {
+                        sym_args.push(Rc::clone(arg));
+                    }
+                    result.push(unflatten_binary_expr(
+                        &sym_args,
+                        *op,
+                        UnflattenStrategy::Left,
+                    ));
+                    result.push(unflatten_binary_expr(
+                        &sym_args,
+                        *op,
+                        UnflattenStrategy::Right,
+                    ));
+                    sym_args.clear();
+                }
+                result
+            }
+            _ => vec![expr],
+        },
+        _ => vec![expr],
+    }
+}
+
+fn get_flattened_binary_args(expr: Rc<Expr>, op: BinaryOperator) -> VecDeque<Rc<Expr>> {
+    match expr.as_ref() {
+        Expr::BinaryExpr(child) if child.op == op => {
+            let mut args = VecDeque::with_capacity(2);
+            for arg in get_flattened_binary_args(Rc::clone(&child.lhs), op)
+                .into_iter()
+                .rev()
+            {
+                args.push_front(arg);
+            }
+            args.append(&mut get_flattened_binary_args(Rc::clone(&child.rhs), op));
+            args
+        }
+        _ => vec![expr].into_iter().collect(),
+    }
+}
+
+enum UnflattenStrategy {
+    Left,  // (+ (+ 1 2) 3)
+    Right, // (+ 1 (+ 2 3))
+}
+
+fn unflatten_binary_expr<E>(
+    args: &[Rc<E>],
+    op: BinaryOperator,
+    strategy: UnflattenStrategy,
+) -> Rc<E>
+where
+    E: Expression,
+{
+    fn _left<E: Expression>(args: &[Rc<E>], op: BinaryOperator) -> Rc<E> {
+        let mut args = args.iter();
+        let mut lhs = Rc::clone(args.next().unwrap());
+        for rhs in args {
+            lhs = Rc::new(
+                BinaryExpr {
+                    op,
+                    lhs,
+                    rhs: Rc::clone(rhs),
+                }
+                .into(),
+            );
+        }
+        lhs
+    }
+
+    fn _right<E: Expression>(args: &[Rc<E>], op: BinaryOperator) -> Rc<E> {
+        let mut args = args.iter().rev();
+        let mut rhs = Rc::clone(args.next().unwrap());
+        for lhs in args {
+            rhs = Rc::new(
+                BinaryExpr {
+                    op,
+                    lhs: Rc::clone(lhs),
+                    rhs,
+                }
+                .into(),
+            );
+        }
+        rhs
+    }
+
+    match strategy {
+        UnflattenStrategy::Left => _left(args, op),
+        UnflattenStrategy::Right => _right(args, op),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{parse_expression, scan};
+
+    fn parse<T: Into<String>>(s: T) -> Rc<Expr> {
+        let toks = scan(s);
+        match parse_expression(toks) {
+            (Stmt::Expr(expr), _) => Rc::new(expr),
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn get_symmetric_expressions_add() {
+        let parsed = parse("1 - 2 + 3 + (x * 4) + 5");
+        let exprs: Vec<String> = get_symmetric_expressions(parsed)
+            .into_iter()
+            .map(|e| e.to_string())
+            .collect();
+
+        assert_eq!(
+            exprs,
+            vec![
+                // Same versions with left and right associativity
+                "1 - 2 + 3 + (x * 4) + 5",
+                "1 - 2 + 3 + (x * 4) + 5",
+                "3 + 1 - 2 + (x * 4) + 5",
+                "3 + 1 - 2 + (x * 4) + 5",
+                "(x * 4) + 1 - 2 + 3 + 5",
+                "(x * 4) + 1 - 2 + 3 + 5",
+                "5 + 1 - 2 + 3 + (x * 4)",
+                "5 + 1 - 2 + 3 + (x * 4)",
+            ]
+        );
+    }
+
+    #[test]
+    fn get_symmetric_expressions_mult() {
+        let parsed = parse("1 ^ 2 * 3 * (x - 4) * 5");
+        let exprs: Vec<String> = get_symmetric_expressions(parsed)
+            .into_iter()
+            .map(|e| e.to_string())
+            .collect();
+
+        assert_eq!(
+            exprs,
+            vec![
+                // Same versions with left and right associativity
+                "1 ^ 2 * 3 * (x - 4) * 5",
+                "1 ^ 2 * 3 * (x - 4) * 5",
+                "3 * 1 ^ 2 * (x - 4) * 5",
+                "3 * 1 ^ 2 * (x - 4) * 5",
+                "(x - 4) * 1 ^ 2 * 3 * 5",
+                "(x - 4) * 1 ^ 2 * 3 * 5",
+                "5 * 1 ^ 2 * 3 * (x - 4)",
+                "5 * 1 ^ 2 * 3 * (x - 4)",
+            ]
+        );
+    }
+
+    #[test]
+    fn flattened_binary_args() {
+        let expr = parse("1 - 2 + 3 + 4 * 5 + 6");
+        let args: Vec<String> = get_flattened_binary_args(expr, BinaryOperator::Plus)
+            .into_iter()
+            .map(|e| e.to_string())
+            .collect();
+
+        assert_eq!(args, vec!["1 - 2", "3", "4 * 5", "6"]);
+    }
+
+    #[test]
+    fn unflatten_binary_expr_right() {
+        let args: Vec<Rc<Expr>> = vec!["1", "2", "3", "4"].into_iter().map(parse).collect();
+        let expr = unflatten_binary_expr(&args, BinaryOperator::Plus, UnflattenStrategy::Right);
+
+        match expr.as_ref() {
+            Expr::BinaryExpr(BinaryExpr { op, lhs, rhs }) => {
+                assert_eq!(*op, BinaryOperator::Plus);
+
+                assert_eq!(lhs.to_string(), "1");
+                match rhs.as_ref() {
+                    Expr::BinaryExpr(BinaryExpr { op, lhs, rhs }) => {
+                        assert_eq!(*op, BinaryOperator::Plus);
+
+                        assert_eq!(lhs.to_string(), "2");
+                        match rhs.as_ref() {
+                            Expr::BinaryExpr(BinaryExpr { op, lhs, rhs }) => {
+                                assert_eq!(*op, BinaryOperator::Plus);
+                                assert_eq!(lhs.to_string(), "3");
+                                assert_eq!(rhs.to_string(), "4");
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn unflatten_binary_expr_left() {
+        let args: Vec<Rc<Expr>> = vec!["1", "2", "3", "4"].into_iter().map(parse).collect();
+        let expr = unflatten_binary_expr(&args, BinaryOperator::Plus, UnflattenStrategy::Left);
+
+        match expr.as_ref() {
+            Expr::BinaryExpr(BinaryExpr { op, lhs, rhs }) => {
+                assert_eq!(*op, BinaryOperator::Plus);
+
+                match lhs.as_ref() {
+                    Expr::BinaryExpr(BinaryExpr { op, lhs, rhs }) => {
+                        assert_eq!(*op, BinaryOperator::Plus);
+
+                        match lhs.as_ref() {
+                            Expr::BinaryExpr(BinaryExpr { op, lhs, rhs }) => {
+                                assert_eq!(*op, BinaryOperator::Plus);
+                                assert_eq!(lhs.to_string(), "1");
+                                assert_eq!(rhs.to_string(), "2");
+                            }
+                            _ => unreachable!(),
+                        }
+                        assert_eq!(rhs.to_string(), "3");
+                    }
+                    _ => unreachable!(),
+                }
+                assert_eq!(rhs.to_string(), "4");
+            }
+            _ => unreachable!(),
+        }
+    }
+}


### PR DESCRIPTION
We do this by flattening binary expressions, rewriting with various
associativities, and running the rewritten expressions on various rules.
If a rewritten expression can be applied by the rule, we use it.
Otherwise we use the rewritten expression whose partial transformation
is the "least complex" (i.e. has the least # of operations).

This still doesn't fix something like `"1 + 2 -b + 3 + a"`. I need to
think more on that. @luke-bhan if you'd like, have a go on it.

Closes #55