### PR TITLE
Small refactor of evaluation process

### DIFF
--- a/libslide/src/evaluator_rules/registry/fn_rules.rs
+++ b/libslide/src/evaluator_rules/registry/fn_rules.rs
@@ -1,8 +1,11 @@
 use crate::grammar::*;
+use crate::utils::*;
+
+use std::rc::Rc;
 
 macro_rules! get_binary_args {
     ($expr:expr, $op:pat) => {
-        match $expr {
+        match $expr.as_ref() {
             Expr::BinaryExpr(BinaryExpr { op: $op, lhs, rhs }) => {
                 match (lhs.as_ref(), rhs.as_ref()) {
                     (Expr::Const(l), Expr::Const(r)) => Some((l, r)),
@@ -14,52 +17,82 @@ macro_rules! get_binary_args {
     };
 }
 
+macro_rules! get_flattened_binary_args {
+    ($expr:expr, $op:expr) => {
+        match $expr.as_ref() {
+            Expr::BinaryExpr(child) if child.op == $op => {
+                Some(get_flattened_binary_args($expr, $op))
+            }
+            _ => None,
+        }
+    };
+}
+
 macro_rules! get_unary_arg {
     ($expr:expr, $op:pat) => {
-        match $expr {
+        match $expr.as_ref() {
             Expr::UnaryExpr(UnaryExpr { op: $op, rhs }) => Some(rhs),
             _ => None,
         }
     };
 }
 
-pub(super) fn add(expr: &Expr) -> Option<Expr> {
-    let (l, r) = get_binary_args!(expr, BinaryOperator::Plus)?;
-    Some(Expr::Const(l + r))
+pub(super) fn add(expr: Rc<Expr>) -> Option<Rc<Expr>> {
+    let mut args = get_flattened_binary_args!(expr, BinaryOperator::Plus)?;
+    let mut konst = 0.;
+    let mut i = 0;
+    for _ in 0..args.len() {
+        match args[i].as_ref() {
+            Expr::Const(f) => {
+                konst += f;
+                args.swap_remove(i);
+            }
+            _ => i += 1,
+        }
+    }
+    if konst != 0. {
+        args.push(Rc::new(konst.into()));
+    }
+
+    Some(unflatten_binary_expr(
+        &args,
+        BinaryOperator::Plus,
+        UnflattenStrategy::Left,
+    ))
 }
 
-pub(super) fn subtract(expr: &Expr) -> Option<Expr> {
+pub(super) fn subtract(expr: Rc<Expr>) -> Option<Rc<Expr>> {
     let (l, r) = get_binary_args!(expr, BinaryOperator::Minus)?;
-    Some(Expr::Const(l - r))
+    Some(Rc::new(Expr::Const(l - r)))
 }
 
-pub(super) fn multiply(expr: &Expr) -> Option<Expr> {
+pub(super) fn multiply(expr: Rc<Expr>) -> Option<Rc<Expr>> {
     let (l, r) = get_binary_args!(expr, BinaryOperator::Mult)?;
-    Some(Expr::Const(l * r))
+    Some(Rc::new(Expr::Const(l * r)))
 }
 
-pub(super) fn divide(expr: &Expr) -> Option<Expr> {
+pub(super) fn divide(expr: Rc<Expr>) -> Option<Rc<Expr>> {
     let (l, r) = get_binary_args!(expr, BinaryOperator::Div)?;
-    Some(Expr::Const(l / r))
+    Some(Rc::new(Expr::Const(l / r)))
 }
 
-pub(super) fn modulo(expr: &Expr) -> Option<Expr> {
+pub(super) fn modulo(expr: Rc<Expr>) -> Option<Rc<Expr>> {
     let (l, r) = get_binary_args!(expr, BinaryOperator::Mod)?;
-    Some(Expr::Const(l % r))
+    Some(Rc::new(Expr::Const(l % r)))
 }
 
-pub(super) fn exponentiate(expr: &Expr) -> Option<Expr> {
+pub(super) fn exponentiate(expr: Rc<Expr>) -> Option<Rc<Expr>> {
     let (l, r) = get_binary_args!(expr, BinaryOperator::Exp)?;
-    Some(Expr::Const(l.powf(*r)))
+    Some(Rc::new(Expr::Const(l.powf(*r))))
 }
 
-pub(super) fn posate(expr: &Expr) -> Option<Expr> {
-    get_unary_arg!(expr, UnaryOperator::SignPositive).map(|e| e.as_ref().clone())
+pub(super) fn posate(expr: Rc<Expr>) -> Option<Rc<Expr>> {
+    get_unary_arg!(expr, UnaryOperator::SignPositive).map(Rc::clone)
 }
 
-pub(super) fn negate(expr: &Expr) -> Option<Expr> {
+pub(super) fn negate(expr: Rc<Expr>) -> Option<Rc<Expr>> {
     match get_unary_arg!(expr, UnaryOperator::SignNegative)?.as_ref() {
-        Expr::Const(n) => Some(Expr::Const(-n)),
+        Expr::Const(n) => Some(Rc::new(Expr::Const(-n))),
         _ => None,
     }
 }

--- a/libslide/src/evaluator_rules/unbuilt_rule.rs
+++ b/libslide/src/evaluator_rules/unbuilt_rule.rs
@@ -1,5 +1,7 @@
 use crate::grammar::Expr;
 
+use std::rc::Rc;
+
 /// An unbuilt rule, generally used to express a rule in a human-readable form.
 #[derive(Copy, Clone)]
 pub enum UnbuiltRule {
@@ -38,7 +40,7 @@ pub enum UnbuiltRule {
     S(&'static str),
 
     /// A function rule.
-    F(fn(&Expr) -> Option<Expr>),
+    F(fn(Rc<Expr>) -> Option<Rc<Expr>>),
 }
 
 impl From<&'static str> for UnbuiltRule {

--- a/libslide/src/partial_evaluator.rs
+++ b/libslide/src/partial_evaluator.rs
@@ -115,7 +115,7 @@ mod tests {
         reorder_constants_nested_right: "1 + 2 + a" => "a + 3"
 
         distribute_negation:            "-(a - b)"     => "b - a"
-        distribute_negation_nested:     "1 + -(a - b)" => "1 + b - a"
+        distribute_negation_nested:     "1 + -(a - b)" => "b - a + 1"
         distribute_negation_with_eval:  "1 + -(2 - 3)" => "2"
 
         unwrap_parens_const:            "(1)"       => "1"

--- a/libslide/src/utils/grammar.rs
+++ b/libslide/src/utils/grammar.rs
@@ -38,7 +38,7 @@ pub fn get_symmetric_expressions(expr: Rc<Expr>) -> Vec<Rc<Expr>> {
     }
 }
 
-fn get_flattened_binary_args(expr: Rc<Expr>, op: BinaryOperator) -> VecDeque<Rc<Expr>> {
+pub fn get_flattened_binary_args(expr: Rc<Expr>, op: BinaryOperator) -> Vec<Rc<Expr>> {
     match expr.as_ref() {
         Expr::BinaryExpr(child) if child.op == op => {
             let mut args = VecDeque::with_capacity(2);
@@ -48,19 +48,19 @@ fn get_flattened_binary_args(expr: Rc<Expr>, op: BinaryOperator) -> VecDeque<Rc<
             {
                 args.push_front(arg);
             }
-            args.append(&mut get_flattened_binary_args(Rc::clone(&child.rhs), op));
-            args
+            args.extend(&mut get_flattened_binary_args(Rc::clone(&child.rhs), op).drain(..));
+            args.into_iter().collect()
         }
-        _ => vec![expr].into_iter().collect(),
+        _ => vec![expr],
     }
 }
 
-enum UnflattenStrategy {
+pub enum UnflattenStrategy {
     Left,  // (+ (+ 1 2) 3)
     Right, // (+ 1 (+ 2 3))
 }
 
-fn unflatten_binary_expr<E>(
+pub fn unflatten_binary_expr<E>(
     args: &[Rc<E>],
     op: BinaryOperator,
     strategy: UnflattenStrategy,


### PR DESCRIPTION
I am looking into some way to evaluate expressions like

```
1 + 2 - b + 3 + a
```

To do this, I think the best way forward is to flatten math expressions
with negation rewritten as subtraction. That is, the expression above
should become

```
1 + 2 + -b + 3 + a
```

The code to do this should belong to the `add` rule. As a precursor,
this commit sets up `add` to fold constants in a flattened expression,
and changes symmetric expression pattern matching to only happen in a
string matching context (that is the only place we really care about it,
since a function rule should be able to handle any analysis it needs
itself).