### PR TITLE
Eval fn test fail

### DIFF
--- a/libslide/src/evaluator_rules/registry.rs
+++ b/libslide/src/evaluator_rules/registry.rs
@@ -178,7 +178,7 @@ impl fmt::Display for BuildRuleErrors {
             .map(|(i, r)| format!("({}) {}", i + 1, r.to_string()))
             .map(|s| indent(s, 4))
             .collect::<Vec<_>>()
-            .join("\n\n");
+            .join("\n");
 
         write!(
             f,
@@ -218,7 +218,6 @@ mod tests {
     (1) Could not resolve pattern map
         "_a -> _b"
     Specifically, source "_a" is missing pattern(s) "_b" present in target "_b"
-
     (2) Could not resolve pattern map
         "$a -> $a - _c"
     Specifically, source "$a" is missing pattern(s) "_c" present in target "$a - _c""##


### PR DESCRIPTION
This issue occurs to because the spacing in the test does not consistently translate when you use cargo fmt --all. The solution is just to remove it by formatting the rule errors without a line between them. I think this is fine formatting and saves me the headache of fixing this on every PR.