### PR TITLE
Bignum bench

### DIFF
--- a/libslide/Cargo.toml
+++ b/libslide/Cargo.toml
@@ -25,6 +25,12 @@ path = "benches/bignum/add.rs"
 harness = false
 required-features = ["benchmark-internals"]
 
+[[bench]]
+name = "sub"
+path = "benches/bignum/sub.rs"
+harness = false
+required-features = ["benchmark-internals"]
+
 [dependencies.num-traits]
 version = "0.2"
 default-features = false

--- a/libslide/Cargo.toml
+++ b/libslide/Cargo.toml
@@ -19,6 +19,12 @@ path = "benches/bignum/modulo.rs"
 harness = false
 required-features = ["benchmark-internals"]
 
+[[bench]]
+name = "add"
+path = "benches/bignum/add.rs"
+harness = false
+required-features = ["benchmark-internals"]
+
 [dependencies.num-traits]
 version = "0.2"
 default-features = false
@@ -26,3 +32,4 @@ features = ["std"]
 
 [dev-dependencies]
 criterion = "0.3.2"
+lazy_static = "1.4.0"

--- a/libslide/Cargo.toml
+++ b/libslide/Cargo.toml
@@ -14,8 +14,26 @@ harness = false
 required-features = ["benchmark-internals"]
 
 [[bench]]
-name = "modulo"
+name = "ctor"
+path = "benches/bignum/constructor.rs"
+harness = false
+required-features = ["benchmark-internals"]
+
+[[bench]]
+name = "compare"
+path = "benches/bignum/compare.rs"
+harness = false
+required-features = ["benchmark-internals"]
+
+[[bench]]
+name = "mod"
 path = "benches/bignum/modulo.rs"
+harness = false
+required-features = ["benchmark-internals"]
+
+[[bench]]
+name = "mul"
+path = "benches/bignum/mul.rs"
 harness = false
 required-features = ["benchmark-internals"]
 
@@ -31,6 +49,12 @@ path = "benches/bignum/sub.rs"
 harness = false
 required-features = ["benchmark-internals"]
 
+[[bench]]
+name = "fft"
+path = "benches/bignum/utils/fft.rs"
+harness = false
+required-features = ["benchmark-internals"]
+
 [dependencies.num-traits]
 version = "0.2"
 default-features = false
@@ -38,4 +62,4 @@ features = ["std"]
 
 [dev-dependencies]
 criterion = "0.3.2"
-lazy_static = "1.4.0"
+criterion-macro = "0.3.2"

--- a/libslide/benches/bignum/add.rs
+++ b/libslide/benches/bignum/add.rs
@@ -8,15 +8,13 @@ use libslide::{Bignum, _add};
 use lazy_static::lazy_static;
 
 lazy_static! {
-    static ref INPUT: [(Bignum, Bignum); 4] = 
+    static ref INPUT: [(Bignum, Bignum); 3] = 
         [(Bignum::new("99999999999999999999999999999999".to_string()).unwrap(), 
             Bignum::new("999999999999999999999".to_string()).unwrap()), 
         (Bignum::new("0.555555555555555555555555555".to_string()).unwrap(), 
             Bignum::new("0.555555555555555555".to_string()).unwrap()),
         (Bignum::new("99999999999999.999999999999".to_string()).unwrap(),
-            Bignum::new("99999999999.99999".to_string()).unwrap()), 
-        (Bignum::new("-99999999999999.999999999999".to_string()).unwrap(),
-            Bignum::new("-99999999999.99999".to_string()).unwrap())];
+            Bignum::new("99999999999.99999".to_string()).unwrap())];
 }
 
 fn bench_add(c: &mut Criterion) {

--- a/libslide/benches/bignum/add.rs
+++ b/libslide/benches/bignum/add.rs
@@ -1,0 +1,33 @@
+#[macro_use]
+extern crate criterion;
+extern crate libslide;
+extern crate lazy_static;
+
+use criterion::Criterion;
+use libslide::{Bignum, _add};
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref INPUT: [(Bignum, Bignum); 4] = 
+        [(Bignum::new("99999999999999999999999999999999".to_string()).unwrap(), 
+            Bignum::new("999999999999999999999".to_string()).unwrap()), 
+        (Bignum::new("0.555555555555555555555555555".to_string()).unwrap(), 
+            Bignum::new("0.555555555555555555".to_string()).unwrap()),
+        (Bignum::new("99999999999999.999999999999".to_string()).unwrap(),
+            Bignum::new("99999999999.99999".to_string()).unwrap()), 
+        (Bignum::new("-99999999999999.999999999999".to_string()).unwrap(),
+            Bignum::new("-99999999999.99999".to_string()).unwrap())];
+}
+
+fn bench_add(c: &mut Criterion) {
+    c.bench_function("add", |b| {
+        b.iter(|| {
+            for (u, v) in INPUT.iter() {
+                _add(u.to_owned(), v.to_owned());
+            }
+        })
+    });
+}
+
+criterion_group!(add_benches, bench_add);
+criterion_main!(add_benches);

--- a/libslide/benches/bignum/add.rs
+++ b/libslide/benches/bignum/add.rs
@@ -1,31 +1,31 @@
 #[macro_use]
 extern crate criterion;
 extern crate libslide;
-extern crate lazy_static;
 
 use criterion::Criterion;
 use libslide::{Bignum, _add};
-use lazy_static::lazy_static;
 
-lazy_static! {
-    static ref INPUT: [(Bignum, Bignum); 3] = 
-        [(Bignum::new("99999999999999999999999999999999".to_string()).unwrap(), 
-            Bignum::new("999999999999999999999".to_string()).unwrap()), 
-        (Bignum::new("0.555555555555555555555555555".to_string()).unwrap(), 
-            Bignum::new("0.555555555555555555".to_string()).unwrap()),
-        (Bignum::new("99999999999999.999999999999".to_string()).unwrap(),
-            Bignum::new("99999999999.99999".to_string()).unwrap())];
+macro_rules! bench_add {
+    ($($name: ident: $size: expr)*)=> {
+        $(
+        fn $name(c: &mut Criterion) -> () {
+            c.bench_function(concat!("add_", $size), |b| {
+                b.iter(|| {
+                    let u = String::from_utf8(vec![b'9'; $size]).unwrap();
+                    let v = String::from_utf8(vec![b'5'; $size]).unwrap();
+                    _add(Bignum::new(u).unwrap(), Bignum::new(v).unwrap());
+                })
+            });
+        }
+    )*
+    }
 }
 
-fn bench_add(c: &mut Criterion) {
-    c.bench_function("add", |b| {
-        b.iter(|| {
-            for (u, v) in INPUT.iter() {
-                _add(u.to_owned(), v.to_owned());
-            }
-        })
-    });
+bench_add! {
+    size_1024: 1024
+    size_2048: 2048
+    size_4096: 4096
 }
 
-criterion_group!(add_benches, bench_add);
+criterion_group!(add_benches, size_1024, size_2048, size_4096);
 criterion_main!(add_benches);

--- a/libslide/benches/bignum/compare.rs
+++ b/libslide/benches/bignum/compare.rs
@@ -1,0 +1,35 @@
+#[macro_use]
+extern crate criterion;
+extern crate libslide;
+
+use criterion::Criterion;
+use libslide::{Bignum, _compare};
+
+const CASES: [&str; 5] = ["eq", "lte", "lt", "gte", "gt"];
+
+macro_rules! bench_bignum_cmp {
+    ($($name: ident: $size: expr)*)=> {
+        $(
+        fn $name(c: &mut Criterion) -> () {
+            for item in CASES.iter() {
+                c.bench_function(&(concat!("Bignum_", $size, "_cmp_").to_string() + (*item)), |b| {
+                    b.iter(|| {
+                        let u = String::from_utf8(vec![b'9'; $size]).unwrap();
+                        let v = String::from_utf8(vec![b'5'; $size]).unwrap();
+                        _compare(Bignum::new(u.to_string()).unwrap(), Bignum::new(v.to_string()).unwrap(), item);
+                   })
+                });
+            }
+        }
+    )*
+    }
+}
+
+bench_bignum_cmp! {
+    size_1024: 1024
+    size_2048: 2048
+    size_4096: 4096
+}
+
+criterion_group!(bignum_cmp_benches, size_1024, size_2048, size_4096);
+criterion_main!(bignum_cmp_benches);

--- a/libslide/benches/bignum/constructor.rs
+++ b/libslide/benches/bignum/constructor.rs
@@ -3,17 +3,16 @@ extern crate criterion;
 extern crate libslide;
 
 use criterion::Criterion;
-use libslide::{Bignum, _add};
+use libslide::Bignum;
 
-macro_rules! bench_add {
+macro_rules! bench_bignum_constructor {
     ($($name: ident: $size: expr)*)=> {
         $(
         fn $name(c: &mut Criterion) -> () {
-            c.bench_function(concat!("Bignum_", $size, "_add"), |b| {
+            c.bench_function(concat!("Bignum_", $size, "_constructor"), |b| {
                 b.iter(|| {
                     let u = String::from_utf8(vec![b'9'; $size]).unwrap();
-                    let v = String::from_utf8(vec![b'5'; $size]).unwrap();
-                    _add(Bignum::new(u).unwrap(), Bignum::new(v).unwrap());
+                    Bignum::new(u.to_string()).unwrap();
                 })
             });
         }
@@ -21,11 +20,11 @@ macro_rules! bench_add {
     }
 }
 
-bench_add! {
+bench_bignum_constructor! {
     size_1024: 1024
     size_2048: 2048
     size_4096: 4096
 }
 
-criterion_group!(add_benches, size_1024, size_2048, size_4096);
-criterion_main!(add_benches);
+criterion_group!(ctor_benches, size_1024, size_2048, size_4096);
+criterion_main!(ctor_benches);

--- a/libslide/benches/bignum/modulo.rs
+++ b/libslide/benches/bignum/modulo.rs
@@ -1,19 +1,25 @@
 #[macro_use]
 extern crate criterion;
 extern crate libslide;
+extern crate lazy_static;
 
 use criterion::Criterion;
 use libslide::{Bignum, _binary_skip_mod, _single_skip_mod};
+use lazy_static::lazy_static;
 
-const INPUT: [(&str, &str); 2] = [("92138591", "29135"), ("10201231.1235123", "139581")];
+lazy_static! {
+    static ref INPUT: [(Bignum, Bignum); 2] = 
+        [(Bignum::new("92138591".to_string()).unwrap() , 
+            Bignum::new("29135".to_string()).unwrap()),
+         (Bignum::new("10201231.1235123".to_string()).unwrap(),
+            Bignum::new("139581".to_string()).unwrap())];
+}
 
 fn bench_binary_modulo(c: &mut Criterion) {
     c.bench_function("binary_modulo", |b| {
         b.iter(|| {
             for (u, v) in INPUT.iter() {
-                let lhs = Bignum::new((*u).to_string()).unwrap();
-                let rhs = Bignum::new((*v).to_string()).unwrap();
-                _binary_skip_mod(lhs, rhs);
+                _binary_skip_mod(u.to_owned(), v.to_owned());
             }
         })
     });
@@ -23,9 +29,7 @@ fn bench_single_modulo(c: &mut Criterion) {
     c.bench_function("single_modulo", |b| {
         b.iter(|| {
             for (u, v) in INPUT.iter() {
-                let lhs = Bignum::new((*u).to_string()).unwrap();
-                let rhs = Bignum::new((*v).to_string()).unwrap();
-                _single_skip_mod(lhs, rhs);
+                _single_skip_mod(u.to_owned(), v.to_owned());
             }
         })
     });

--- a/libslide/benches/bignum/modulo.rs
+++ b/libslide/benches/bignum/modulo.rs
@@ -5,45 +5,38 @@ extern crate libslide;
 use criterion::Criterion;
 use libslide::{Bignum, _binary_skip_mod, _single_skip_mod};
 
+const CASES: [&str; 2] = ["binary_skip", "single_skip"];
+
 macro_rules! bench_mod {
-    ($($name: ident: $size: expr, $mode: expr)*) => {
+    ($($name: ident: $size: expr)*) => {
         $(
         fn $name(c: &mut Criterion) -> () {
-            match $mode {
-                1 => {
-                    c.bench_function(concat!("binary_skip_modulo_", $size), |b| {
-                        b.iter(|| {
-                            let u = String::from_utf8(vec![b'9'; $size]).unwrap();
-                            let v = String::from_utf8(vec![b'2'; $size]).unwrap();
-                            _binary_skip_mod(Bignum::new(u).unwrap(), Bignum::new(v).unwrap());
-                        })
-                    });
-                    
-                }, 
-                2 => {
-                    c.bench_function(concat!("single_skip_modulo_", $size), |b| {
-                        b.iter(|| {
-                            let u = String::from_utf8(vec![b'9';$size]).unwrap();
-                            let v = String::from_utf8(vec![b'2';$size/10]).unwrap();
-                            _single_skip_mod(Bignum::new(u).unwrap(), Bignum::new(v).unwrap());
-                        })
-                    });
-                }, 
-                _ => unreachable!(),
+            let mut group = c.benchmark_group("mod");
+            group.sample_size(10);
+            for item in CASES.iter() {
+                group.bench_function(&(concat!("Bignum_", $size, "_modulo_").to_string() + (*item)), |b| {
+                    b.iter(|| {
+                        let u = String::from_utf8(vec![b'9'; $size]).unwrap();
+                        let v = String::from_utf8(vec![b'5'; $size]).unwrap();
+                        match *item {
+                            "binary_skip" => _binary_skip_mod(Bignum::new(u.to_string()).unwrap(), Bignum::new(v.to_string()).unwrap()),
+                            "single_skip" => _single_skip_mod(Bignum::new(u.to_string()).unwrap(), Bignum::new(v.to_string()).unwrap()),
+                            _ => unreachable!(),
+                        }
+                    })
+                });
             }
+            group.finish();
         }
     )*
     }
 }
 
 bench_mod! {
-    size_1024_bin: 1024, 1
-    size_2048_bin: 2048, 1
-    size_4096_bin: 4096, 1
-    size_1024_sin: 1024, 2
-    size_2048_sin: 2048, 2
-    size_4096_sin: 4096, 2
+    size_1024: 1024
+    size_2048: 2048
+    size_4096: 4096
 }
 
-criterion_group!(mod_benches, size_1024_bin, size_2048_bin, size_4096_bin, size_1024_sin, size_2048_sin, size_4096_sin);
+criterion_group!(mod_benches, size_1024, size_2048, size_4096);
 criterion_main!(mod_benches);

--- a/libslide/benches/bignum/mul.rs
+++ b/libslide/benches/bignum/mul.rs
@@ -3,29 +3,32 @@ extern crate criterion;
 extern crate libslide;
 
 use criterion::Criterion;
-use libslide::{Bignum, _add};
+use libslide::{Bignum, _mul};
 
-macro_rules! bench_add {
+macro_rules! bench_mul {
     ($($name: ident: $size: expr)*)=> {
         $(
         fn $name(c: &mut Criterion) -> () {
-            c.bench_function(concat!("Bignum_", $size, "_add"), |b| {
+            let mut group = c.benchmark_group("mul");
+            group.sample_size(10);
+            group.bench_function(concat!("Bignum_", $size, "_mul"), |b| {
                 b.iter(|| {
                     let u = String::from_utf8(vec![b'9'; $size]).unwrap();
                     let v = String::from_utf8(vec![b'5'; $size]).unwrap();
-                    _add(Bignum::new(u).unwrap(), Bignum::new(v).unwrap());
+                    _mul(Bignum::new(u).unwrap(), Bignum::new(v).unwrap());
                 })
             });
+            group.finish();
         }
     )*
     }
 }
 
-bench_add! {
+bench_mul! {
     size_1024: 1024
     size_2048: 2048
     size_4096: 4096
 }
 
-criterion_group!(add_benches, size_1024, size_2048, size_4096);
-criterion_main!(add_benches);
+criterion_group!(bench_mul, size_1024, size_2048, size_4096);
+criterion_main!(bench_mul);

--- a/libslide/benches/bignum/sub.rs
+++ b/libslide/benches/bignum/sub.rs
@@ -1,0 +1,31 @@
+#[macro_use]
+extern crate criterion;
+extern crate libslide;
+extern crate lazy_static;
+
+use criterion::Criterion;
+use libslide::{Bignum, _sub};
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref INPUT: [(Bignum, Bignum); 3] = 
+        [(Bignum::new("9000000000".to_string()).unwrap(),
+            Bignum::new("101000000000000000000".to_string()).unwrap()),
+        (Bignum::new("0.999999999999999999999900000000000000".to_string()).unwrap(),
+            Bignum::new("0.55555539999999999999".to_string()).unwrap()), 
+        (Bignum::new("99999999999999.999999999999".to_string()).unwrap(), 
+            Bignum::new("100000000000000000000000000".to_string()).unwrap())];
+}
+
+fn bench_sub(c: &mut Criterion) {
+    c.bench_function("sub",|b| {
+        b.iter(|| {
+            for (u, v) in INPUT.iter() {
+                _sub(u.to_owned(), v.to_owned());
+            }
+        })
+    });
+}
+
+criterion_group!(sub_benches, bench_sub);
+criterion_main!(sub_benches);

--- a/libslide/benches/bignum/sub.rs
+++ b/libslide/benches/bignum/sub.rs
@@ -1,31 +1,31 @@
 #[macro_use]
 extern crate criterion;
 extern crate libslide;
-extern crate lazy_static;
 
 use criterion::Criterion;
 use libslide::{Bignum, _sub};
-use lazy_static::lazy_static;
 
-lazy_static! {
-    static ref INPUT: [(Bignum, Bignum); 3] = 
-        [(Bignum::new("9000000000".to_string()).unwrap(),
-            Bignum::new("101000000000000000000".to_string()).unwrap()),
-        (Bignum::new("0.999999999999999999999900000000000000".to_string()).unwrap(),
-            Bignum::new("0.55555539999999999999".to_string()).unwrap()), 
-        (Bignum::new("99999999999999.999999999999".to_string()).unwrap(), 
-            Bignum::new("100000000000000000000000000".to_string()).unwrap())];
+macro_rules! bench_sub {
+    ($($name: ident: $size: expr)*)=> {
+        $(
+        fn $name(c: &mut Criterion) -> () {
+            c.bench_function(concat!("Bignum_", $size, "_sub"), |b| {
+                b.iter(|| {
+                    let v = String::from_utf8(vec![b'9'; $size]).unwrap();
+                    let u = String::from_utf8(vec![b'1'; $size]).unwrap();
+                    _sub(Bignum::new(u).unwrap(), Bignum::new(v).unwrap());
+                })
+            });
+        }
+    )*
+    }
 }
 
-fn bench_sub(c: &mut Criterion) {
-    c.bench_function("sub",|b| {
-        b.iter(|| {
-            for (u, v) in INPUT.iter() {
-                _sub(u.to_owned(), v.to_owned());
-            }
-        })
-    });
+bench_sub! {
+    size_1024: 1024
+    size_2048: 2048
+    size_4096: 4096
 }
 
-criterion_group!(sub_benches, bench_sub);
+criterion_group!(sub_benches, size_1024, size_2048, size_4096);
 criterion_main!(sub_benches);

--- a/libslide/benches/bignum/utils/fft.rs
+++ b/libslide/benches/bignum/utils/fft.rs
@@ -1,0 +1,29 @@
+#[macro_use]
+extern crate criterion;
+extern crate libslide;
+
+use criterion::Criterion;
+use libslide::_fft;
+
+macro_rules! bench_fft {
+    ($($name: ident: $size: expr)*)=> {
+        $(
+        fn $name(c: &mut Criterion) -> () {
+            c.bench_function(concat!("Bignum_", $size, "_utils_fft"), |b| {
+                b.iter(|| {
+                    _fft(vec![9; $size]);
+                })
+            });
+        }
+    )*
+    }
+}
+
+bench_fft! {
+    size_1024: 1024
+    size_2048: 2048
+    size_4096: 4096
+}
+
+criterion_group!(fft_benches, size_1024, size_2048, size_4096);
+criterion_main!(fft_benches);

--- a/libslide/src/bignum.rs
+++ b/libslide/src/bignum.rs
@@ -8,9 +8,12 @@ mod negate;
 mod sub;
 mod utils;
 
-pub use modulo::*;
-pub use add::*;
-pub use sub::*;
+pub use add::_add;
+pub use compare::_compare;
+pub use modulo::{_binary_skip_mod, _single_skip_mod};
+pub use mul::_mul;
+pub use sub::_sub;
+pub use utils::_fft;
 // this probably can go in utils but I put it in here for now
 fn to_u8(c: char) -> u8 {
     c.to_digit(10).unwrap() as u8

--- a/libslide/src/bignum.rs
+++ b/libslide/src/bignum.rs
@@ -9,6 +9,7 @@ mod sub;
 mod utils;
 
 pub use modulo::*;
+pub use add::*;
 // this probably can go in utils but I put it in here for now
 fn to_u8(c: char) -> u8 {
     c.to_digit(10).unwrap() as u8

--- a/libslide/src/bignum.rs
+++ b/libslide/src/bignum.rs
@@ -10,6 +10,7 @@ mod utils;
 
 pub use modulo::*;
 pub use add::*;
+pub use sub::*;
 // this probably can go in utils but I put it in here for now
 fn to_u8(c: char) -> u8 {
     c.to_digit(10).unwrap() as u8

--- a/libslide/src/bignum/add.rs
+++ b/libslide/src/bignum/add.rs
@@ -82,6 +82,11 @@ impl ops::Add for Bignum {
     }
 }
 
+#[cfg(feature = "benchmark-internals")]
+pub fn _add(u: Bignum, v: Bignum) -> Bignum {
+    u + v
+}
+
 #[cfg(test)]
 mod tests {
     macro_rules! bignum_test_add {

--- a/libslide/src/bignum/compare.rs
+++ b/libslide/src/bignum/compare.rs
@@ -65,6 +65,18 @@ impl PartialOrd for Bignum {
     }
 }
 
+#[cfg(feature = "benchmark-internals")]
+pub fn _compare(u: Bignum, v: Bignum, s: &str) -> bool {
+    match s {
+        "eq" => u == v,
+        "lte" => u <= v,
+        "lt" => u < v,
+        "gte" => u >= v,
+        "gt" => u > v,
+        _ => unreachable!(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     macro_rules! bignum_test_cmp {

--- a/libslide/src/bignum/mul.rs
+++ b/libslide/src/bignum/mul.rs
@@ -69,6 +69,11 @@ impl ops::Mul for Bignum {
     }
 }
 
+#[cfg(feature = "benchmark-internals")]
+pub fn _mul(u: Bignum, v: Bignum) -> Bignum {
+    u * v
+}
+
 #[cfg(test)]
 mod tests {
     macro_rules! bignum_test_mul {

--- a/libslide/src/bignum/sub.rs
+++ b/libslide/src/bignum/sub.rs
@@ -84,6 +84,11 @@ impl ops::Sub for Bignum {
     }
 }
 
+#[cfg(feature = "benchmark-internals")]
+pub fn _sub(u: Bignum, v: Bignum) -> Bignum {
+    u - v
+}
+
 #[cfg(test)]
 mod tests {
     macro_rules! bignum_test_sub {

--- a/libslide/src/bignum/utils.rs
+++ b/libslide/src/bignum/utils.rs
@@ -103,6 +103,12 @@ pub fn fft(item: Vec<Complex>, n: usize, ifft: bool) -> Vec<Complex> {
     a
 }
 
+#[cfg(feature = "benchmark-internals")]
+pub fn _fft(v: Vec<u8>) -> Vec<Complex> {
+    let vlen = v.len();
+    fft(recast_user_vec(v).unwrap(), vlen, false)
+}
+
 pub fn ifft(item: Vec<Complex>, n: usize) -> Vec<Complex> {
     let n_complex = Complex::new(n as f64, 0.0);
     let a: Vec<Complex> = fft(item, n, true)


### PR DESCRIPTION
This PR is big sorry, but its pretty repetitive. This implements benchmarks at sizes of 1024, 2048, and 4096 for all of the bignum operators as well as the fft in utils and bignum compare methods. This is more for me to use later when I begin to try and improve our bignums speed. (For example, modulo will have to be rewritten, it is way too slow, but this will be just division once i figure out newton-raphson and get that algo working). 

There will be rebase issues since we recently merged stuff since I started working on it. I will fix them and let you know when this is good for review.