### PR TITLE
remove deps from docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
   - scripts/check lintformat
 
 after_success:
-  - cargo doc --document-private-items
+  - cargo doc --document-private-items --no-deps
 
 deploy:
   - provider: pages


### PR DESCRIPTION
closes #88
Also, we should probably rewrite how we are handling docs, because on travis builds probably isn't a good long term solution.