### PR TITLE
Support outputting result in s-expression or debug form

### DIFF
--- a/libslide/src/grammar/pattern.rs
+++ b/libslide/src/grammar/pattern.rs
@@ -17,8 +17,27 @@ pub enum ExprPat {
     Bracketed(Rc<Self>),
 }
 
-impl Grammar for ExprPat {}
-impl Grammar for Rc<ExprPat> {}
+impl Grammar for ExprPat {
+    fn s_form(&self) -> String {
+        match self {
+            Self::Const(konst) => konst.to_string(),
+            Self::VarPat(pat) | Self::ConstPat(pat) | Self::AnyPat(pat) => pat.to_string(),
+            Self::BinaryExpr(BinaryExpr { op, lhs, rhs }) => {
+                format!("({} {} {})", op.to_string(), lhs.s_form(), rhs.s_form())
+            }
+            Self::UnaryExpr(UnaryExpr { op, rhs }) => {
+                format!("({} {})", op.to_string(), rhs.s_form())
+            }
+            Self::Parend(inner) => format!("({})", inner.s_form()),
+            Self::Bracketed(inner) => format!("[{}]", inner.s_form()),
+        }
+    }
+}
+impl Grammar for Rc<ExprPat> {
+    fn s_form(&self) -> String {
+        self.as_ref().s_form()
+    }
+}
 impl Expression for ExprPat {
     #[inline]
     fn is_const(&self) -> bool {

--- a/libslide/src/lib.rs
+++ b/libslide/src/lib.rs
@@ -11,6 +11,8 @@ pub use partial_evaluator::EvaluatorContext;
 
 mod evaluator_rules;
 mod grammar;
+pub use grammar::Grammar;
+
 mod math;
 
 #[cfg(feature = "benchmark-internals")]

--- a/slide/Cargo.toml
+++ b/slide/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 
 [dependencies]
 libslide = { path = "../libslide" }
+clap = "2.33.1"


### PR DESCRIPTION
Also adds an option to dump the AST after parsing.

Closes #96
Closes #97