### PR TITLE
Flatten expressions commutatively

### DIFF
--- a/libslide/src/evaluator_rules/registry.rs
+++ b/libslide/src/evaluator_rules/registry.rs
@@ -201,9 +201,11 @@ mod tests {
         let rule_set = RuleSet::default();
         let built_rules = rule_set.build().unwrap();
 
-        assert!(built_rules
-            .into_iter()
-            .any(|s| s.to_string() == "_a + 0 -> _a"));
+        assert!(
+            built_rules
+                .into_iter()
+                .any(|s| s.to_string() == "_a + 0 -> _a")
+        );
     }
 
     #[test]

--- a/libslide/src/evaluator_rules/rule.rs
+++ b/libslide/src/evaluator_rules/rule.rs
@@ -320,8 +320,10 @@ Specifically, source "_a + $b / #c * 3" is missing pattern(s) "#e", "_f" present
 
     #[test]
     fn validate_ok() {
-        assert!(PatternMap::from_str("_a + $b / #c -> _a + $b")
-            .validate()
-            .is_none());
+        assert!(
+            PatternMap::from_str("_a + $b / #c -> _a + $b")
+                .validate()
+                .is_none()
+        );
     }
 }

--- a/libslide/src/grammar.rs
+++ b/libslide/src/grammar.rs
@@ -294,6 +294,23 @@ pub struct BinaryExpr<E: Expression> {
     pub rhs: Rc<E>,
 }
 
+impl<E> BinaryExpr<E>
+where
+    E: Expression,
+{
+    pub fn mult<T, U>(lhs: T, rhs: U) -> Self
+    where
+        T: Into<Rc<E>>,
+        U: Into<Rc<E>>,
+    {
+        Self {
+            op: BinaryOperator::Mult,
+            lhs: lhs.into(),
+            rhs: rhs.into(),
+        }
+    }
+}
+
 macro_rules! display_binary_expr {
     (<$expr:ident>) => {
         impl fmt::Display for BinaryExpr<$expr> {
@@ -363,6 +380,21 @@ impl fmt::Display for UnaryOperator {
 pub struct UnaryExpr<E: Expression> {
     pub op: UnaryOperator,
     pub rhs: Rc<E>,
+}
+
+impl<E> UnaryExpr<E>
+where
+    E: Expression,
+{
+    pub fn negate<T>(expr: T) -> Self
+    where
+        T: Into<Rc<E>>,
+    {
+        Self {
+            op: UnaryOperator::SignNegative,
+            rhs: expr.into(),
+        }
+    }
 }
 
 macro_rules! display_unary_expr {

--- a/libslide/src/partial_evaluator/flatten.rs
+++ b/libslide/src/partial_evaluator/flatten.rs
@@ -1,0 +1,141 @@
+use crate::grammar::*;
+use crate::utils::{unflatten_binary_expr, UnflattenStrategy};
+
+use std::collections::{HashMap, VecDeque};
+use std::rc::Rc;
+
+pub fn flatten_expr(expr: &Rc<Expr>) -> Rc<Expr> {
+    match expr.as_ref() {
+        Expr::Const(_) | Expr::Var(_) => Rc::clone(expr),
+        Expr::Parend(inner) | Expr::Bracketed(inner) => Rc::clone(inner),
+        Expr::BinaryExpr(BinaryExpr { op, lhs, rhs })
+            if op == &BinaryOperator::Plus || op == &BinaryOperator::Minus =>
+        {
+            flatten_add_or_sub(lhs, rhs, op == &BinaryOperator::Minus)
+        }
+        // TODO: handle everything else
+        _ => Rc::clone(expr),
+    }
+}
+
+pub fn flatten_add_or_sub(o_lhs: &Rc<Expr>, o_rhs: &Rc<Expr>, is_subtract: bool) -> Rc<Expr> {
+    let lhs = flatten_expr(o_lhs);
+    let rhs = flatten_expr(o_rhs);
+
+    let mut coeff = 0.;
+    let mut terms = HashMap::<&Rc<Expr>, f64>::new();
+    let mut args = VecDeque::with_capacity(2);
+    let base_args = [lhs, rhs];
+    args.extend(base_args.iter());
+    let mut args_before_neg = 1;
+    while let Some(arg) = args.pop_front() {
+        let is_neg = is_subtract && args_before_neg == 0;
+        args_before_neg -= 1;
+
+        match arg.as_ref() {
+            Expr::Const(konst) => {
+                if is_neg {
+                    coeff -= konst;
+                } else {
+                    coeff += konst;
+                }
+            }
+            Expr::BinaryExpr(BinaryExpr {
+                op: BinaryOperator::Plus,
+                lhs,
+                rhs,
+            }) => {
+                if is_neg {
+                    args.push_back(lhs);
+                    args.push_back(rhs);
+                } else {
+                    args.push_front(lhs);
+                    args.push_front(rhs);
+                    args_before_neg += 2;
+                }
+            }
+            _ => {
+                // TODO: handle everything else more granularly
+                let entry = terms.entry(arg).or_insert(0.);
+                if is_neg {
+                    *entry -= 1.;
+                } else {
+                    *entry += 1.;
+                }
+            }
+        }
+    }
+
+    let mut new_args: Vec<Rc<Expr>> = Vec::with_capacity(1 + terms.len());
+    if coeff != 0. {
+        new_args.push(Rc::from(Expr::Const(coeff)));
+    }
+    for (term, coeff) in terms {
+        if coeff == 0. {
+            continue;
+        } else if (coeff - 1.).abs() < std::f64::EPSILON {
+            // coeff == 1
+            new_args.push(Rc::clone(term));
+        } else if (coeff - -1.).abs() < std::f64::EPSILON {
+            // coeff == -1
+            let neg = UnaryExpr::negate(Rc::clone(term));
+            new_args.push(Rc::from(Expr::UnaryExpr(neg)));
+        } else {
+            let mult = BinaryExpr::mult(Expr::Const(coeff), Rc::clone(term));
+            let expr: Expr = mult.into();
+            new_args.push(Rc::from(expr));
+        }
+    }
+
+    match new_args.len() {
+        0 => Rc::from(Expr::Const(0.)),
+        1 => new_args.remove(0),
+        _ => unflatten_binary_expr(&new_args, BinaryOperator::Plus, UnflattenStrategy::Left),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::flatten_expr;
+    use crate::grammar::*;
+    use crate::utils::normalize;
+    use crate::{parse_expression, scan};
+
+    use std::rc::Rc;
+
+    fn parse(program: &str) -> Expr {
+        let tokens = scan(program);
+        let (parsed, _) = parse_expression(tokens);
+        match parsed {
+            Stmt::Expr(expr) => expr,
+            _ => unreachable!(),
+        }
+    }
+
+    static CASES: &[&str] = &[
+        "1 + 2 + 3 -> 6",
+        "1 + x + x -> (+ 1 (* x 2))",
+        // TODO: currently (+ x (* 2 x))
+        // "x + x + x -> (* 3 x)",
+        "x + y + 1 -> (+ (+ x y) 1)",
+        "x + 0 -> x",
+        "1 - 1 -> 0",
+        "1 + 2 - 3 -> 0",
+        "1 - 2 + 3 -> 2",
+        "a - a + 1 -> 1",
+        "a + 1 - 1 -> a",
+    ];
+
+    #[test]
+    fn flatten_cases() {
+        for case in CASES {
+            let mut split = case.split(" -> ");
+            let expr = parse(split.next().unwrap());
+            let expected_flattened = split.next().unwrap();
+
+            let flattened = normalize(flatten_expr(&Rc::from(expr))).s_form();
+
+            assert_eq!(flattened, expected_flattened);
+        }
+    }
+}

--- a/libslide/src/partial_evaluator/types.rs
+++ b/libslide/src/partial_evaluator/types.rs
@@ -2,12 +2,14 @@ use crate::evaluator_rules::RuleName;
 
 pub struct EvaluatorContext {
     pub(crate) rule_blacklist: Vec<RuleName>,
+    pub(crate) always_flatten: bool,
 }
 
 impl Default for EvaluatorContext {
     fn default() -> Self {
         Self {
             rule_blacklist: vec![],
+            always_flatten: true,
         }
     }
 }
@@ -18,6 +20,11 @@ impl EvaluatorContext {
         T: Into<Vec<RuleName>>,
     {
         self.rule_blacklist = rule_blacklist.into();
+        self
+    }
+
+    pub fn always_flatten(mut self, flatten: bool) -> Self {
+        self.always_flatten = flatten;
         self
     }
 }

--- a/libslide/src/utils/grammar.rs
+++ b/libslide/src/utils/grammar.rs
@@ -55,9 +55,7 @@ macro_rules! insert_back {
 pub fn get_flattened_binary_args(expr: Rc<Expr>, parent_op: BinaryOperator) -> Vec<Rc<Expr>> {
     match expr.as_ref() {
         Expr::BinaryExpr(
-            child
-            @
-            BinaryExpr {
+            child @ BinaryExpr {
                 op: BinaryOperator::Plus,
                 ..
             },
@@ -72,9 +70,7 @@ pub fn get_flattened_binary_args(expr: Rc<Expr>, parent_op: BinaryOperator) -> V
         }
 
         Expr::BinaryExpr(
-            child
-            @
-            BinaryExpr {
+            child @ BinaryExpr {
                 op: BinaryOperator::Mult,
                 ..
             },
@@ -89,9 +85,7 @@ pub fn get_flattened_binary_args(expr: Rc<Expr>, parent_op: BinaryOperator) -> V
         }
 
         Expr::BinaryExpr(
-            child
-            @
-            BinaryExpr {
+            child @ BinaryExpr {
                 op: BinaryOperator::Minus,
                 ..
             },


### PR DESCRIPTION
This commit adds an option to flatten/fold expressions a little bit smarter
than we currently do by flattening and folding an expression
commutatively.

Not sure if there should be a better name, like `flat_fold` or similar?
Or we can rename the current usages of `flatten` and `unflatten`, which
don't do any expression folding, to `rollup` and `unroll` or similar.
Feedback wanted on this.

Closes #92