### PR TITLE
Setup system tests and test harness

### DIFF
--- a/ladder
+++ b/ladder
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+import argparse
+from argparse import RawTextHelpFormatter
+import os
+import sys
+import subprocess
+
+
+def test(args, runner_args):
+    cargo_args = ["cargo", "test"]
+    env = os.environ.copy()
+    if args.sys:
+        cargo_args.append("--test")
+        cargo_args.append("system_tests")
+    cargo_args.append("--")
+    cargo_args.append("--test-threads")
+    cargo_args.append(str(args.threads))
+    for runner_arg in unknown:
+        cargo_args.append(runner_arg)
+    cargo_args.append("--")
+    if args.filter:
+        cargo_args.append(args.filter)
+
+    if args.bless:
+        env["BLESS"] = "1"
+
+    process = subprocess.run(cargo_args, env=env)
+    sys.exit(process.returncode)
+
+
+def bench(args, _unknown):
+    os.chdir("libslide")
+    cargo_args = ["cargo", "bench"]
+    if args.filter:
+        cargo_args.append(args.filter)
+    cargo_args.append("--features")
+    cargo_args.append("benchmark-internals")
+
+    process = subprocess.run(cargo_args)
+    sys.exit(process.returncode)
+
+
+def lf(args, _unknown):
+    process = subprocess.run(["./scripts/check", "lf"])
+    sys.exit(process.returncode)
+
+
+parser = argparse.ArgumentParser(
+    prog="ladder",
+    description="ladder: the slide development tool.",
+    formatter_class=RawTextHelpFormatter
+)
+sub_parsers = parser.add_subparsers(help="ladder subcommands")
+
+test_parser = sub_parsers.add_parser(
+    "test",
+    help="Run slide tests",
+    formatter_class=RawTextHelpFormatter,
+    description="""
+Runs slide tests using cargo. Arguments to the underlying "cargo test" runners
+can be passed as extra flags on this command.
+
+This command accepts an optional positional argument that serves as a test
+filter. If no filter is specified, all tests are run.
+
+To run only system tests, pass --sys.
+
+Examples:
+
+> ladder test                  # runs all tests
+> ladder test --sys --bless    # runs all system tests and accepts their output
+> ladder test --quiet          # runs `cargo test` in quiet mode
+> ladder test add              # only runs tests with "add" in their name
+"""
+)
+test_parser.add_argument(
+    "filter",
+    nargs="?",
+    help="""Optional test filter. If not specified, all tests are run."""
+)
+test_parser.add_argument(
+    "--sys",
+    action="store_true",
+    default=False,
+    help="""Only run system tests."""
+)
+test_parser.add_argument(
+    "-t", "--threads",
+    type=int,
+    default=4,
+    help="""The number of threads that should be used to run the tests."""
+)
+test_parser.add_argument(
+    "--bless",
+    action="store_true",
+    default=False,
+    help="""Accept the output of tests as new baselines.
+This only affects system tests."""
+)
+test_parser.set_defaults(handler=test)
+
+bench_parser = sub_parsers.add_parser(
+    "bench",
+    help="Run slide benchmarks",
+    formatter_class=RawTextHelpFormatter,
+    description="""
+Run libslide benchmarks using cargo.
+
+This command accepts an optional positional argument that serves as a benchmark
+filter. If no filter is specified, all benchmarks are run.
+"""
+)
+bench_parser.add_argument(
+    "filter",
+    nargs="?",
+    help="Optional benchmark filter. If not specified, all benchmarks are run."
+)
+bench_parser.set_defaults(handler=bench)
+
+lf_parser = sub_parsers.add_parser("lf", help="Run lint and format checks")
+lf_parser.set_defaults(handler=lf)
+
+argv = sys.argv[1:]
+if not argv:
+    parser.print_help()
+    sys.exit(1)
+args, unknown = parser.parse_known_args(argv)
+if ("handler" not in args):
+    parser.print_help()
+else:
+    args.handler(args, unknown)

--- a/slide/Cargo.toml
+++ b/slide/Cargo.toml
@@ -7,3 +7,12 @@ edition = "2018"
 [dependencies]
 libslide = { path = "../libslide" }
 clap = "2.33.1"
+
+[[test]]
+name = "system_tests"
+path = "src/test/mod.rs"
+harness = false
+
+[dev-dependencies]
+libtest-mimic = { git = "https://github.com/ayazhafiz/libtest-mimic", branch = "master" }
+difference = "2.0.0"

--- a/slide/src/lib.rs
+++ b/slide/src/lib.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod test;

--- a/slide/src/test/README.md
+++ b/slide/src/test/README.md
@@ -1,0 +1,137 @@
+# slide system tests
+
+This directory provides a runner for slide's system tests. System tests should be added to
+subdirectories of this directory.
+
+A system test checks the standard output and error for a run of a program through the slide CLI. If
+needed, a system test can specify CLI options to be used in the test.
+
+Slide system tests have the form
+
+```
+!!!args
+<CLI args>
+!!!args
+
+===in
+<program input>
+===in
+
+~~~stdout
+<standard output>
+~~~stdout
+
+~~~stderr
+<standard output>
+~~~stderr
+```
+
+The `!!!args` clause is optional; it does not need to be included if your test does not require
+non-default CLI arguments.
+
+We highly suggest running system tests via slide's [ladder](../../../ladder) build manager.
+
+```bash
+ladder test --sys         # run all system tests
+ladder test --sys --bless # accept system test outputs as baselines
+```
+
+## Example workflow
+
+Let's say we want to add a test to check that `x + 1 + 2 -> x + 3`. To start, create a `.slide` test
+file with the input:
+
+```
+===in
+x + 1 + 2
+===in
+```
+
+We're going to ask the test runner to generate the output of the program for us, and then we can do
+a manual check to make sure the results are correct. To bless the system tests, run
+
+```
+ladder test --sys --bless
+```
+
+The contents of the test file should now be
+
+```
+===in
+x + 1 + 2
+===in
+
+~~~stdout
+x + 3
+~~~stdout
+
+~~~stderr
+~~~stderr
+```
+
+Awesome! Exactly what we expected.
+
+Now, let's say we want to check that the s-expression form of evaluation is correct. We need to add
+an explicit args clause, because s-expression output is not a default output of slide.
+
+```
+!!!args
+-o s-expression
+!!!args
+
+===in
+x + 1 + 2
+===in
+
+~~~stdout
+x + 3
+~~~stdout
+
+~~~stderr
+~~~stderr
+```
+
+Let's see what happens when we run the test:
+
+```
+ladder test --sys
+
+running 1 test
+test [system] ui/add_x_1_2.slide ... FAILED
+
+failures:
+
+---- ui/add_x_1_2.slide ----
+Mismatch in stdout:
+-x + 3
+
++(+ x 3)
+```
+
+We forgot to update the expected output! Let's do that now (either manually or with `--bless`):
+
+```
+!!!args
+-o s-expression
+!!!args
+
+===in
+x + 1 + 2
+===in
+
+~~~stdout
+(+ x 3)
+~~~stdout
+
+~~~stderr
+~~~stderr
+```
+
+Running the tests again, we now get a success.
+
+```
+ladder test --sys
+
+running 1 test
+test [system] ui/add_x_1_2.slide ... ok
+```

--- a/slide/src/test/mod.rs
+++ b/slide/src/test/mod.rs
@@ -1,0 +1,234 @@
+use difference::{Changeset, Difference};
+use libtest_mimic::{run_tests, Arguments, LineFormat, LinePrinter, Outcome, Test};
+use std::env;
+use std::error::Error;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+
+/// Collects all `.slide` system test files, starting from slide/src/test and visiting all nested
+/// directories.
+fn collect_tests() -> Result<Vec<Test<PathBuf>>, Box<dyn Error>> {
+    let root_test_path = Path::new("src/test");
+    let mut dirs_to_visit = vec![root_test_path.to_path_buf()];
+    let mut tests = Vec::with_capacity(200);
+    while let Some(dir) = dirs_to_visit.pop() {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let entry_type = entry.file_type()?;
+            if entry_type.is_dir() {
+                dirs_to_visit.push(path);
+                continue;
+            }
+            if path.extension() == Some(OsStr::new("slide")) {
+                let name = path.strip_prefix(root_test_path)?.display().to_string();
+
+                tests.push(Test {
+                    name,
+                    kind: "system".into(),
+                    is_ignored: false,
+                    is_bench: false,
+                    data: path,
+                })
+            }
+        }
+    }
+    Ok(tests)
+}
+
+/// Describes a test case
+struct TestCase {
+    args: String,
+    input: String,
+    stdout: String,
+    stderr: String,
+}
+
+/// Returns the delimiter for a test case clause in a .slide test file.
+fn get_clause_delim(clause: &str) -> String {
+    let prefix = match clause {
+        "args" => "!!!",
+        "in" => "===",
+        "stdout" | "stderr" => "~~~",
+        _ => unreachable!(),
+    };
+    format!("{}{}", prefix, clause)
+}
+
+/// Creates a TestCase from a .slide test file.
+fn mk_test_case(mut content: String, bless: bool) -> Result<TestCase, Outcome> {
+    let clause_names = ["args", "in", "stdout", "stderr"];
+    let mut clauses = Vec::with_capacity(clause_names.len());
+    for clause in clause_names.iter() {
+        if bless && (clause == &"stdout" || clause == &"stderr") {
+            // These will get updated later, so just make them empty for now.
+            clauses.push("".into());
+            continue;
+        }
+
+        let clause_delim = get_clause_delim(clause);
+        let mut splits: Vec<_> = content
+            .split(&format!("{}\n", clause_delim))
+            .map(String::from)
+            .collect();
+        if splits.len() != 3 {
+            if clause == &"args" {
+                // Args are optional.
+                clauses.push("".into());
+                content = splits.pop().unwrap();
+                continue;
+            }
+            return Err(Outcome::Failed {
+                msg: Some(atomic_lock(move |printer: &mut dyn LinePrinter| {
+                    printer.print_line(
+                        &format!("{} clause missing in test case.", clause_delim),
+                        &LineFormat::Failure,
+                    );
+                    printer.print_line(
+                        &format!(
+                            r#"Hint: add a
+
+{clause_delim}
+<text>
+{clause_delim}
+
+section to the test file."#,
+                            clause_delim = clause_delim
+                        ),
+                        &LineFormat::Suggestion,
+                    );
+                })),
+            });
+        }
+        content = splits.pop().unwrap();
+        clauses.push(splits.pop().unwrap());
+    }
+    let mut clauses = clauses.into_iter();
+
+    Ok(TestCase {
+        args: clauses.next().unwrap(),
+        input: clauses.next().unwrap(),
+        stdout: clauses.next().unwrap(),
+        stderr: clauses.next().unwrap(),
+    })
+}
+
+/// Prints a diff between two texts.
+fn print_diff(printer: &mut dyn LinePrinter, text1: &str, text2: &str) {
+    let Changeset { diffs, .. } = Changeset::new(text1, text2, "\n");
+
+    for diff in diffs {
+        let (content, prefix, fmt) = match diff {
+            Difference::Same(ref x) => (x, " ", &LineFormat::Text),
+            Difference::Add(ref x) => (x, "+", &LineFormat::Success),
+            Difference::Rem(ref x) => (x, "-", &LineFormat::Failure),
+        };
+        printer.print_line(&format!("{}{}", prefix, content), fmt);
+    }
+}
+
+/// Generates the contents of a blessed file for a test case.
+fn mk_bless_file(test_case: &TestCase, stdout: &str, stderr: &str) -> String {
+    let mut content = String::with_capacity(256);
+    let mut push = |clause: &str, clause_content: &str| {
+        let clause_delim = get_clause_delim(clause);
+        content.push_str(&format!("{}\n", clause_delim));
+        content.push_str(clause_content);
+        content.push_str(&format!("{}\n\n", clause_delim));
+    };
+    if !test_case.args.is_empty() {
+        push("args", &test_case.args);
+    }
+    push("in", &test_case.input);
+    push("stdout", stdout);
+    push("stderr", stderr);
+    content.pop(); // drop trailing newline
+    content
+}
+
+/// Wraps an object in a thread-safe atomic mutex.
+fn atomic_lock<T>(obj: T) -> Arc<Mutex<T>> {
+    Arc::new(Mutex::new(obj))
+}
+
+/// Runs a slide system test.
+fn drive_test(test: &Test<PathBuf>) -> Outcome {
+    let bless = env::var("BLESS") == Ok("1".into());
+
+    let path = &test.data;
+    let content = fs::read(path).unwrap_or_else(|_| panic!("Failed to read {}", path.display()));
+    let content = String::from_utf8(content)
+        .unwrap_or_else(|_| panic!("{} is not valid UTF-8", path.display()));
+
+    let test_case = match mk_test_case(content, bless) {
+        Ok(tc) => tc,
+        Err(outcome) => return outcome,
+    };
+
+    let mut cmd = Command::new("cargo");
+    cmd.arg("run");
+    cmd.arg("-q");
+    cmd.arg("--");
+    for arg in test_case.args.lines() {
+        for sub_arg in arg.split(' ') {
+            if arg.is_empty() {
+                continue;
+            }
+            cmd.arg(sub_arg);
+        }
+    }
+    cmd.arg(&test_case.input);
+
+    let cmd = match cmd.output() {
+        Ok(cmd) => cmd,
+        Err(e) => {
+            return Outcome::Failed {
+                msg: Some(atomic_lock(move |printer: &mut dyn LinePrinter| {
+                    printer.print_line(&e.to_string(), &LineFormat::Failure);
+                })),
+            };
+        }
+    };
+
+    let stdout = String::from_utf8(cmd.stdout).unwrap();
+    let stderr = String::from_utf8(cmd.stderr).unwrap();
+
+    if bless {
+        let blessed = mk_bless_file(&test_case, &stdout, &stderr);
+        return match fs::write(path, blessed) {
+            Ok(_) => Outcome::Passed,
+            Err(e) => Outcome::Failed {
+                msg: Some(atomic_lock(move |printer: &mut dyn LinePrinter| {
+                    printer.print_line(&e.to_string(), &LineFormat::Failure);
+                })),
+            },
+        };
+    }
+
+    if stdout != test_case.stdout || stderr != test_case.stderr {
+        return Outcome::Failed {
+            msg: Some(atomic_lock(move |printer: &mut dyn LinePrinter| {
+                if stdout != test_case.stdout {
+                    printer.print_line("Mismatch in stdout:", &LineFormat::Text);
+                    print_diff(printer, &test_case.stdout, &stdout);
+                }
+                if stderr != test_case.stderr {
+                    printer.print_line("Mismatch in stderr:", &LineFormat::Text);
+                    print_diff(printer, &test_case.stderr, &stderr);
+                }
+            })),
+        };
+    }
+
+    Outcome::Passed
+}
+
+#[allow(unused)]
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = Arguments::from_args();
+    let tests = collect_tests()?;
+    run_tests(&args, tests, drive_test).exit();
+}

--- a/slide/src/test/ui/add.slide
+++ b/slide/src/test/ui/add.slide
@@ -1,0 +1,10 @@
+===in
+1 + 1 + 1
+===in
+
+~~~stdout
+3
+~~~stdout
+
+~~~stderr
+~~~stderr

--- a/slide/src/test/ui/add_x_1_2.slide
+++ b/slide/src/test/ui/add_x_1_2.slide
@@ -1,0 +1,14 @@
+!!!args
+-o s-expression
+!!!args
+
+===in
+x + 1 + 2
+===in
+
+~~~stdout
+(+ x 3)
+~~~stdout
+
+~~~stderr
+~~~stderr

--- a/slide/src/test/ui/output_form/debug.slide
+++ b/slide/src/test/ui/output_form/debug.slide
@@ -1,0 +1,43 @@
+!!!args
+--parse-only
+-o debug
+!!!args
+
+===in
+1 + 5 / 10 + 2
+===in
+
+~~~stdout
+Expr(
+    BinaryExpr(
+        BinaryExpr {
+            op: Plus,
+            lhs: BinaryExpr(
+                BinaryExpr {
+                    op: Plus,
+                    lhs: Const(
+                        1.0,
+                    ),
+                    rhs: BinaryExpr(
+                        BinaryExpr {
+                            op: Div,
+                            lhs: Const(
+                                5.0,
+                            ),
+                            rhs: Const(
+                                10.0,
+                            ),
+                        },
+                    ),
+                },
+            ),
+            rhs: Const(
+                2.0,
+            ),
+        },
+    ),
+)
+~~~stdout
+
+~~~stderr
+~~~stderr

--- a/slide/src/test/ui/output_form/pretty.slide
+++ b/slide/src/test/ui/output_form/pretty.slide
@@ -1,0 +1,15 @@
+!!!args
+--parse-only
+-o pretty
+!!!args
+
+===in
+1 + 5 / 10 + 2
+===in
+
+~~~stdout
+1 + 5 / 10 + 2
+~~~stdout
+
+~~~stderr
+~~~stderr

--- a/slide/src/test/ui/output_form/s_expression.slide
+++ b/slide/src/test/ui/output_form/s_expression.slide
@@ -1,0 +1,15 @@
+!!!args
+--parse-only
+-o s-expression
+!!!args
+
+===in
+1 + 5 / 10 + 2
+===in
+
+~~~stdout
+(+ (+ 1 (/ 5 10)) 2)
+~~~stdout
+
+~~~stderr
+~~~stderr


### PR DESCRIPTION
This commit adds a harness for `.slide` system tests, defined under
`slide/src/test`. `.slide` test files have the form

```
!!!args
<CLI args>
!!!args

===in
<program input>
===in

~~~stdout
<standard output>
~~~stdout

~~~stderr
<standard output>
~~~stderr
```

where `!!!args` is an optional clause only needed if the test requires
particular CLI args.

Each test runs through the slide CLI with the specified args and program
input, and the CLI output is checked to match the test-specified stdout
and stderr.

To allow for easy maintainence and updating of tests, tests can be
blessed (have new baselines accepted based off the last test run) using
the new ladder tool:

```
ladder test --sys --bless
```

ladder is a slide development tool that makes it easier to do things
like running system tests. Underneath, the call to run system tests with
a bless is

```
BLESS=1 cargo run -p slide --test slide_tests -- --test_threads=4
```

ladder abstracts this away nicely.

ladder also has a couple other neat features. Running `ladder bench`
will run benchmarks with `--feature=benchmark-internals` passed to cargo
automatically, and `ladder lf` runs `scripts/check lf`.

ladder has some more options; to see them all, try `ladder --help`. I
suggest `alias ladder='./ladder'` so the `./` does not have to be typed.

Closes #104