### PR TITLE
Emit nicely-formatted scanning diagnostics

### DIFF
--- a/libslide/src/common.rs
+++ b/libslide/src/common.rs
@@ -1,0 +1,34 @@
+/// Describes the character span of a substring in a text.
+///
+/// For example, in "abcdef", "bcd" has the span (1, 4).
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub struct Span {
+    /// Inclusive lower bound index of the span
+    pub lo: usize,
+    /// Exclusive upper bound index of the span
+    pub hi: usize,
+}
+
+impl From<(usize, usize)> for Span {
+    fn from(span: (usize, usize)) -> Self {
+        Self {
+            lo: span.0,
+            hi: span.1,
+        }
+    }
+}
+
+impl From<std::ops::Range<usize>> for Span {
+    fn from(span: std::ops::Range<usize>) -> Self {
+        Self {
+            lo: span.start,
+            hi: span.end,
+        }
+    }
+}
+
+impl From<Span> for (usize, usize) {
+    fn from(span: Span) -> Self {
+        (span.lo, span.hi)
+    }
+}

--- a/libslide/src/diagnostics.rs
+++ b/libslide/src/diagnostics.rs
@@ -1,0 +1,51 @@
+use crate::common::Span;
+
+/// The kind of a slide diagnostic.
+pub enum DiagnosticKind {
+    /// An error diagnostic. Generally, this diagnostic should be emitted for unrecoverable errors.
+    /// In other cases, a warning or a note may be more applicable.
+    Error,
+    /// A note diagnostic is a generic annotation with no specific connotation like `error`. It can
+    /// be particularly useful as an associated diagnostic, for example in expanding on a primary
+    /// error.
+    Note,
+}
+
+/// A diagnostic for slide source code.
+pub struct Diagnostic {
+    pub kind: DiagnosticKind,
+    pub span: Span,
+    pub msg: String,
+    pub associated_diagnostics: Vec<Diagnostic>,
+}
+
+impl Diagnostic {
+    /// Creates an error diagnostic at a span.
+    pub(crate) fn span_err<S, M>(span: S, err: M) -> Diagnostic
+    where
+        S: Into<Span>,
+        M: Into<String>,
+    {
+        Diagnostic {
+            kind: DiagnosticKind::Error,
+            span: span.into(),
+            msg: err.into(),
+            associated_diagnostics: Vec::with_capacity(2),
+        }
+    }
+
+    /// Adds a note to the diagnostic, possibly at a different span.
+    pub(crate) fn with_note<S, M>(mut self, span: S, note: M) -> Diagnostic
+    where
+        S: Into<Span>,
+        M: Into<String>,
+    {
+        self.associated_diagnostics.push(Diagnostic {
+            kind: DiagnosticKind::Note,
+            span: span.into(),
+            msg: note.into(),
+            associated_diagnostics: vec![],
+        });
+        self
+    }
+}

--- a/libslide/src/evaluator_rules/pattern_match.rs
+++ b/libslide/src/evaluator_rules/pattern_match.rs
@@ -276,12 +276,12 @@ mod tests {
     use crate::{parse_expression, parse_expression_pattern, scan};
 
     fn parse_rule(prog: &str) -> ExprPat {
-        let (expr, _) = parse_expression_pattern(scan(prog));
+        let (expr, _) = parse_expression_pattern(scan(prog).tokens);
         expr.as_ref().clone()
     }
 
     fn parse_expr(prog: &str) -> Expr {
-        match parse_expression(scan(prog)) {
+        match parse_expression(scan(prog).tokens) {
             (Stmt::Expr(expr), _) => expr,
             _ => unreachable!(),
         }

--- a/libslide/src/evaluator_rules/rule.rs
+++ b/libslide/src/evaluator_rules/rule.rs
@@ -66,7 +66,7 @@ impl PatternMap {
     pub fn from_str(rule: &str) -> Self {
         let split = rule.split(" -> ");
         let mut split = split
-            .map(scan)
+            .map(|toks| scan(toks).tokens)
             .map(parse_expression_pattern)
             .map(|(expr, _)| expr);
 

--- a/libslide/src/lib.rs
+++ b/libslide/src/lib.rs
@@ -1,4 +1,7 @@
-mod scanner;
+pub mod common;
+pub mod diagnostics;
+
+pub mod scanner;
 pub use scanner::scan;
 
 mod parser;

--- a/libslide/src/parser/expression_parser.rs
+++ b/libslide/src/parser/expression_parser.rs
@@ -153,7 +153,7 @@ mod tests {
     #[test]
     fn common_subexpression_elimination() {
         let program = "1 * 2 + 1 * 2";
-        let tokens = scan(program);
+        let tokens = scan(program).tokens;
         let (parsed, _) = parse(tokens);
         let (l, r) = match parsed {
             Stmt::Expr(Expr::BinaryExpr(BinaryExpr { lhs, rhs, .. })) => (lhs, rhs),

--- a/libslide/src/parser/expression_pattern_parser.rs
+++ b/libslide/src/parser/expression_pattern_parser.rs
@@ -123,7 +123,7 @@ mod tests {
     #[test]
     fn common_subexpression_elimination() {
         let program = "$v * #c + $v * #c";
-        let tokens = scan(program);
+        let tokens = scan(program).tokens;
         let (parsed, _) = parse(tokens);
         let (l, r) = match (*parsed).clone() {
             ExprPat::BinaryExpr(BinaryExpr { lhs, rhs, .. }) => (lhs, rhs),

--- a/libslide/src/parser/test_utils.rs
+++ b/libslide/src/parser/test_utils.rs
@@ -8,7 +8,7 @@ macro_rules! __parse {
         } else {
             pin.to_owned()
         };
-        let tokens = scan(pin);
+        let tokens = scan(pin).tokens;
         let (parsed, _) = $parser(tokens);
         assert_eq!(parsed.to_string(), pout);
     };
@@ -51,7 +51,7 @@ macro_rules! parser_error_tests {
             use crate::scanner::{scan};
             use crate::parser::{$parser};
 
-            let tokens = scan($program);
+            let tokens = scan($program).tokens;
             let (_, errors) = $parser(tokens);
             assert_eq!(errors.join("\n"), $error);
         }

--- a/libslide/src/partial_evaluator.rs
+++ b/libslide/src/partial_evaluator.rs
@@ -51,7 +51,7 @@ mod tests {
     use crate::{parse_expression, scan, EvaluatorContext};
 
     fn parse(program: &str) -> Stmt {
-        let tokens = scan(program);
+        let tokens = scan(program).tokens;
         let (parsed, _) = parse_expression(tokens);
         parsed
     }

--- a/libslide/src/partial_evaluator/flatten.rs
+++ b/libslide/src/partial_evaluator/flatten.rs
@@ -161,7 +161,7 @@ mod tests {
     use std::rc::Rc;
 
     fn parse(program: &str) -> Expr {
-        let tokens = scan(program);
+        let tokens = scan(program).tokens;
         let (parsed, _) = parse_expression(tokens);
         match parsed {
             Stmt::Expr(expr) => expr,

--- a/libslide/src/scanner/types.rs
+++ b/libslide/src/scanner/types.rs
@@ -3,6 +3,7 @@
 //
 //
 
+use crate::common::Span;
 use core::fmt;
 
 #[derive(PartialEq, Clone, Debug)]
@@ -61,26 +62,6 @@ pub enum TokenType {
 
     // end of file
     EOF,
-}
-
-/// Describes the character span of a substring in a text.
-///
-/// For example, in "abcdef", "bcd" has the span (1, 4).
-#[derive(PartialEq, Clone, Debug)]
-pub struct Span {
-    /// Inclusive lower bound index of the span
-    pub lo: usize,
-    /// Exclusive upper bound index of the span
-    pub hi: usize,
-}
-
-impl From<(usize, usize)> for Span {
-    fn from(span: (usize, usize)) -> Self {
-        Self {
-            lo: span.0,
-            hi: span.1,
-        }
-    }
 }
 
 /// Describes a token in a slide program.

--- a/libslide/src/utils/grammar.rs
+++ b/libslide/src/utils/grammar.rs
@@ -263,8 +263,8 @@ mod tests {
     use super::*;
     use crate::{parse_expression, parse_expression_pattern, scan};
 
-    fn parse<T: Into<String>>(s: T) -> Rc<Expr> {
-        let toks = scan(s);
+    fn parse(s: &'static str) -> Rc<Expr> {
+        let toks = scan(s).tokens;
         match parse_expression(toks) {
             (Stmt::Expr(expr), _) => Rc::new(expr),
             _ => unreachable!(),
@@ -396,7 +396,7 @@ mod tests {
 
     #[test]
     fn unique_pats() {
-        let parsed = parse_expression_pattern(scan("$a + _b * (#c - [$d]) / $a")).0;
+        let parsed = parse_expression_pattern(scan("$a + _b * (#c - [$d]) / $a").tokens).0;
         let pats = super::unique_pats(&parsed);
 
         let mut pats: Vec<_> = pats

--- a/slide/Cargo.toml
+++ b/slide/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2018"
 [dependencies]
 libslide = { path = "../libslide" }
 clap = "2.33.1"
+annotate-snippets = { version = "0.8.0", features = ["color"] }
+termcolor = "1.1.0"
+atty = "0.2.14"
 
 [[test]]
 name = "system_tests"

--- a/slide/src/diagnostics.rs
+++ b/slide/src/diagnostics.rs
@@ -1,0 +1,67 @@
+use libslide::diagnostics::{Diagnostic, DiagnosticKind};
+
+use annotate_snippets::{
+    display_list::{DisplayList, FormatOptions},
+    snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
+};
+use std::io::Write;
+use termcolor::{BufferedStandardStream, ColorChoice, WriteColor};
+
+pub fn emit_slide_diagnostics(file: Option<&str>, source: String, diagnostics: Vec<Diagnostic>) {
+    let mut stderr = BufferedStandardStream::stderr(ColorChoice::Auto);
+    let can_color = atty::is(atty::Stream::Stderr) && stderr.supports_color();
+
+    for diagnostic in diagnostics {
+        let main_annotation_type = convert_diagnostic_kind(&diagnostic.kind);
+        let mut annotations = Vec::with_capacity(diagnostic.associated_diagnostics.len() + 1);
+        // The first annotation always points to the code that generated this diagnostic.
+        annotations.push(SourceAnnotation {
+            label: "",
+            annotation_type: main_annotation_type,
+            range: diagnostic.span.into(),
+        });
+        // Add the associated diagnostics as the remaining annotations for the main diagnostic.
+        for associated_diagnostic in diagnostic.associated_diagnostics.iter() {
+            annotations.push(convert_diagnostic(associated_diagnostic));
+        }
+
+        let snippet = Snippet {
+            title: Some(Annotation {
+                label: Some(&diagnostic.msg),
+                id: None,
+                annotation_type: main_annotation_type,
+            }),
+            footer: vec![],
+            slices: vec![Slice {
+                source: &source,
+                line_start: 1,
+                origin: file,
+                fold: true,
+                annotations,
+            }],
+            opt: FormatOptions {
+                color: can_color,
+                ..Default::default()
+            },
+        };
+
+        writeln!(&mut stderr, "{}\n", DisplayList::from(snippet)).unwrap();
+    }
+}
+
+/// Converts a slide Diagnostic to a SourceAnnotation.
+fn convert_diagnostic(diagnostic: &Diagnostic) -> SourceAnnotation {
+    SourceAnnotation {
+        label: &diagnostic.msg,
+        annotation_type: convert_diagnostic_kind(&diagnostic.kind),
+        range: diagnostic.span.into(),
+    }
+}
+
+/// Converts a slide DiagnosticKind to an AnnotationType.
+fn convert_diagnostic_kind(diagnostic_kind: &DiagnosticKind) -> AnnotationType {
+    match diagnostic_kind {
+        DiagnosticKind::Error => AnnotationType::Error,
+        DiagnosticKind::Note => AnnotationType::Note,
+    }
+}

--- a/slide/src/main.rs
+++ b/slide/src/main.rs
@@ -1,3 +1,7 @@
+mod diagnostics;
+use diagnostics::emit_slide_diagnostics;
+
+use libslide::scanner::ScanResult;
 use libslide::{evaluate, parse_expression, scan, EvaluatorContext, Grammar};
 
 use std::env;
@@ -52,8 +56,18 @@ fn get_opts() -> Opts {
 
 fn main() -> Result<(), String> {
     let opts = get_opts();
+    let file = None; // currently programs can only be read from stdin
+    let program = opts.program;
 
-    let tokens = scan(opts.program);
+    let ScanResult {
+        tokens,
+        diagnostics,
+    } = scan(&*program);
+    if !diagnostics.is_empty() {
+        emit_slide_diagnostics(file, program, diagnostics);
+        std::process::exit(1);
+    }
+
     let (parse_tree, errors) = parse_expression(tokens);
     if !errors.is_empty() {
         return Err(errors.join("\n"));

--- a/slide/src/test/ui/error/invalid_token.slide
+++ b/slide/src/test/ui/error/invalid_token.slide
@@ -1,0 +1,27 @@
+===in
+9 * 32 @ 4 ~ 10 - 5
+===in
+
+~~~stdout
+~~~stdout
+
+~~~stderr
+error: Invalid token
+  |
+1 | 9 * 32 @ 4 ~ 10 - 5
+  |        ^
+  |        - note: token must be mathematically significant
+  |
+
+error: Invalid token
+  |
+1 | 9 * 32 @ 4 ~ 10 - 5
+  |            ^
+  |            - note: token must be mathematically significant
+  |
+
+~~~stderr
+
+~~~exitcode
+1
+~~~exitcode

--- a/slide/src/test/ui/error/invalid_token_multiline.slide
+++ b/slide/src/test/ui/error/invalid_token_multiline.slide
@@ -1,0 +1,46 @@
+===in
+9 * 32 @
+  4 ~ 10 - 5 `
+10 ,
+===in
+
+~~~stdout
+~~~stdout
+
+~~~stderr
+error: Invalid token
+  |
+1 | 9 * 32 @
+  |        ^
+  |        - note: token must be mathematically significant
+  |
+
+error: Invalid token
+  |
+1 | 9 * 32 @
+2 |   4 ~ 10 - 5 `
+  |     ^
+  |     - note: token must be mathematically significant
+  |
+
+error: Invalid token
+  |
+1 | 9 * 32 @
+2 |   4 ~ 10 - 5 `
+  |              ^
+  |              - note: token must be mathematically significant
+  |
+
+error: Invalid token
+  |
+...
+3 | 10 ,
+  |    ^
+  |    - note: token must be mathematically significant
+  |
+
+~~~stderr
+
+~~~exitcode
+1
+~~~exitcode


### PR DESCRIPTION
This commit adds a diagnostic module and shows that it behaves well by
emitting some simple scanning errors, like if an invalid token is
encountered.

Closes #102