### PR TITLE
Report diagnostic for extra tokens following an expression

### DIFF
--- a/libslide/src/parser.rs
+++ b/libslide/src/parser.rs
@@ -58,6 +58,23 @@ fn unclosed_delimiter(open: Token, expected: TT, found: Token) -> Diagnostic {
     .with_help_note(open.span, format!("opening `{}` here", open))
 }
 
+/// Returns a diagnostic for extra tokens following a primary item.
+/// `extra_tokens` will be consumed in the construction of the diagnostic.
+fn extra_tokens_diag(extra_tokens: &mut PeekIter<Token>) -> Diagnostic {
+    let Span { lo, mut hi } = extra_tokens.peek().unwrap().span;
+    while let Some(tok) = extra_tokens.next() {
+        if extra_tokens.peek().unwrap().ty == TT::EOF {
+            hi = tok.span.hi;
+            break;
+        }
+    }
+    Diagnostic::span_err(
+        lo..hi,
+        "Unexpected extra tokens",
+        "not connected to a primary expression".to_string(),
+    )
+}
+
 trait Parser<T>
 where
     T: Grammar,

--- a/libslide/src/parser/expression_parser.rs
+++ b/libslide/src/parser/expression_parser.rs
@@ -1,4 +1,4 @@
-use super::Parser;
+use super::{extra_tokens_diag, Parser};
 use crate::common::Span;
 use crate::diagnostics::Diagnostic;
 use crate::grammar::*;
@@ -82,7 +82,10 @@ impl Parser<Stmt> for ExpressionParser {
             }
             _ => Stmt::Expr((*self.expr()).clone()),
         };
-        assert!(self.done());
+        if !self.done() {
+            let extra_tokens_diag = extra_tokens_diag(self.input());
+            self.push_diag(extra_tokens_diag);
+        }
         parsed
     }
 

--- a/libslide/src/parser/expression_pattern_parser.rs
+++ b/libslide/src/parser/expression_pattern_parser.rs
@@ -1,4 +1,4 @@
-use super::Parser;
+use super::{extra_tokens_diag, Parser};
 use crate::common::Span;
 use crate::diagnostics::Diagnostic;
 use crate::grammar::*;
@@ -43,7 +43,10 @@ impl Parser<Rc<ExprPat>> for ExpressionPatternParser {
 
     fn parse(&mut self) -> Rc<ExprPat> {
         let parsed = self.expr();
-        assert!(self.done());
+        if !self.done() {
+            let extra_tokens_diag = extra_tokens_diag(self.input());
+            self.push_diag(extra_tokens_diag);
+        }
         parsed
     }
 

--- a/slide/src/test/ui/extra_items.slide
+++ b/slide/src/test/ui/extra_items.slide
@@ -1,0 +1,24 @@
+===in
+1 + 0 -1 2 3
+  4 5 6 / 7 ^ 8
+  9
+===in
+
+~~~stdout
+~~~stdout
+
+~~~stderr
+error: Unexpected extra tokens
+  |
+1 |   1 + 0 -1 2 3
+  |  __________^
+2 | |   4 5 6 / 7 ^ 8
+3 | |   9 
+  | |____^ not connected to a primary expression
+  |
+
+~~~stderr
+
+~~~exitcode
+1
+~~~exitcode

--- a/slide/src/test/ui/extra_items_expr_pat.slide
+++ b/slide/src/test/ui/extra_items_expr_pat.slide
@@ -1,0 +1,28 @@
+!!!args
+--expr-pat
+!!!args
+
+===in
+_a + $b -#c + 1 2
+3 4 5 6 / 7 ^ 8
+  9
+===in
+
+~~~stdout
+~~~stdout
+
+~~~stderr
+error: Unexpected extra tokens
+  |
+1 |   _a + $b -#c + 1 2
+  |  _________________^
+2 | | 3 4 5 6 / 7 ^ 8
+3 | |   9 
+  | |____^ not connected to a primary expression
+  |
+
+~~~stderr
+
+~~~exitcode
+1
+~~~exitcode


### PR DESCRIPTION
Currently we panic, but slide should just report an error instead.

Closes #126